### PR TITLE
feat: adds response cache based on current torn api cache logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <mockito.version>5.14.2</mockito.version>
         <assertj.version>3.26.3</assertj.version>
         <uribuilder.version>2.7.1</uribuilder.version>
+        <caffeine.version>3.1.8</caffeine.version>
 
         <!-- Plugins -->
         <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
@@ -56,6 +57,12 @@
             <groupId>net.moznion</groupId>
             <artifactId>uribuilder-tiny</artifactId>
             <version>${uribuilder.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
         </dependency>
 
         <!-- Testing -->

--- a/src/main/java/eu/tornplayground/tornapi/TornApi.java
+++ b/src/main/java/eu/tornplayground/tornapi/TornApi.java
@@ -1,6 +1,8 @@
 package eu.tornplayground.tornapi;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import eu.tornplayground.tornapi.cache.DefaultResponseCache;
+import eu.tornplayground.tornapi.cache.ResponseCache;
 import eu.tornplayground.tornapi.connector.ApiConnector;
 import eu.tornplayground.tornapi.connector.TornHttpException;
 import eu.tornplayground.tornapi.keyprovider.KeyProvider;
@@ -17,6 +19,7 @@ public class TornApi {
     private final ApiConnector connector;
     private final KeyProvider keyProvider;
     private String defaultComment;
+    private ResponseCache defaultResponseCache;
 
     public TornApi(ApiConnector connector, KeyProvider keyProvider) {
         this.connector = connector;
@@ -25,6 +28,16 @@ public class TornApi {
 
     public TornApi(ApiConnector connector) {
         this(connector, null);
+    }
+
+    public TornApi withDefaultResponseCache(ResponseCache cache) {
+        this.defaultResponseCache = cache;
+        return this;
+    }
+
+    public TornApi withDefaultResponseCache() {
+        this.defaultResponseCache = new DefaultResponseCache();
+        return this;
     }
 
     public String getDefaultComment() {
@@ -104,6 +117,13 @@ public class TornApi {
             return parameters;
         }
 
+        /**
+         * Hash the request data for caching.
+         * Excludes the parameters as they are not used for caching.
+         */
+        public int cacheHash() {
+            return Objects.hash(key, id, section, selections);
+        }
     }
 
     public class ApiSection<T extends Selection> {
@@ -213,19 +233,25 @@ public class TornApi {
         }
 
         public JsonNode fetch() throws IOException, InterruptedException, TornHttpException {
+            RequestData request = new RequestData(key, id, section, selections, parameters);
+
+            if (defaultResponseCache != null && defaultResponseCache.contains(request.cacheHash())) {
+                return defaultResponseCache.get(request.cacheHash());
+            }
+
             URI uri = buildUri();
 
             JsonNode result = connector.connect(uri.toString());
 
-            if (usedProvider) {
-                RequestData request = new RequestData(key, id, section, selections, parameters);
+            if (defaultResponseCache != null) {
+                defaultResponseCache.put(request.cacheHash(), result);
+            }
 
+            if (usedProvider) {
                 keyProvider.listener(request, result);
             }
 
             return result;
         }
-
     }
-
 }

--- a/src/main/java/eu/tornplayground/tornapi/TornApi.java
+++ b/src/main/java/eu/tornplayground/tornapi/TornApi.java
@@ -19,7 +19,7 @@ public class TornApi {
     private final ApiConnector connector;
     private final KeyProvider keyProvider;
     private String defaultComment;
-    private ResponseCache defaultResponseCache;
+    private ResponseCache responseCache;
 
     public TornApi(ApiConnector connector, KeyProvider keyProvider) {
         this.connector = connector;
@@ -30,13 +30,13 @@ public class TornApi {
         this(connector, null);
     }
 
-    public TornApi withDefaultResponseCache(ResponseCache cache) {
-        this.defaultResponseCache = cache;
+    public TornApi withResponseCache(ResponseCache cache) {
+        this.responseCache = cache;
         return this;
     }
 
     public TornApi withDefaultResponseCache() {
-        this.defaultResponseCache = new DefaultResponseCache();
+        this.responseCache = new DefaultResponseCache();
         return this;
     }
 
@@ -235,16 +235,16 @@ public class TornApi {
         public JsonNode fetch() throws IOException, InterruptedException, TornHttpException {
             RequestData request = new RequestData(key, id, section, selections, parameters);
 
-            if (defaultResponseCache != null && defaultResponseCache.contains(request.cacheHash())) {
-                return defaultResponseCache.get(request.cacheHash());
+            if (responseCache != null && responseCache.contains(request.cacheHash())) {
+                return responseCache.get(request.cacheHash());
             }
 
             URI uri = buildUri();
 
             JsonNode result = connector.connect(uri.toString());
 
-            if (defaultResponseCache != null) {
-                defaultResponseCache.put(request.cacheHash(), result);
+            if (responseCache != null && !result.has("error")) {
+                responseCache.put(request.cacheHash(), result);
             }
 
             if (usedProvider) {

--- a/src/main/java/eu/tornplayground/tornapi/cache/DefaultResponseCache.java
+++ b/src/main/java/eu/tornplayground/tornapi/cache/DefaultResponseCache.java
@@ -1,0 +1,36 @@
+package eu.tornplayground.tornapi.cache;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Default implementation of the response cache.
+ * Caches responses for 30 seconds, which is the default limitation of the Torn API.
+ */
+public class DefaultResponseCache implements ResponseCache {
+    private final Cache<Integer, JsonNode> cache;
+
+    public DefaultResponseCache() {
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(30, TimeUnit.SECONDS)
+                .build();
+    }
+
+    @Override
+    public JsonNode get(Integer requestDataHash) {
+        return cache.getIfPresent(requestDataHash);
+    }
+
+    @Override
+    public void put(Integer requestDataHash, JsonNode data) {
+        cache.put(requestDataHash, data);
+    }
+
+    @Override
+    public boolean contains(Integer requestDataHash) {
+        return cache.getIfPresent(requestDataHash) != null;
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/cache/ResponseCache.java
+++ b/src/main/java/eu/tornplayground/tornapi/cache/ResponseCache.java
@@ -1,0 +1,11 @@
+package eu.tornplayground.tornapi.cache;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface ResponseCache {
+    void put(Integer requestDataHash, JsonNode data);
+
+    JsonNode get(Integer requestDataHash);
+
+    boolean contains(Integer requestDataHash);
+}


### PR DESCRIPTION
Same idea as with the Limiter, reduce the amount of "useless" api calls 