### PR TITLE
feat: minor rework of TornApi and adding convenience functionalities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <jackson-jsr310.version>2.18.0</jackson-jsr310.version>
         <junit-jupiter.version>5.11.3</junit-jupiter.version>
         <mockito.version>5.14.2</mockito.version>
-        <assertj.version>3.25.3</assertj.version>
+        <assertj.version>3.26.3</assertj.version>
         <uribuilder.version>2.7.1</uribuilder.version>
 
         <!-- Plugins -->

--- a/src/main/java/eu/tornplayground/tornapi/RepeatingRequestTask.java
+++ b/src/main/java/eu/tornplayground/tornapi/RepeatingRequestTask.java
@@ -1,0 +1,97 @@
+package eu.tornplayground.tornapi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.tornplayground.tornapi.connector.TornHttpException;
+import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
+import eu.tornplayground.tornapi.models.TornError;
+
+import java.io.IOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class RepeatingRequestTask<T> {
+    private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors() * 2);
+    private final long intervalInSeconds;
+    private Consumer<T> resultConsumer;
+    private BiConsumer<TornError, RepeatingRequestTask<T>> tornErrorHandler;
+    private BiConsumer<Exception, RepeatingRequestTask<T>> exceptionHandler;
+    private Consumer<RepeatingRequestTask<T>> requestLimitReachedHandler;
+    private ScheduledFuture<?> scheduledFuture;
+    private final RequestBuilder<?> requestBuilder;
+    private Function<JsonNode, T> mapping;
+
+    public RepeatingRequestTask(long intervalInSeconds, RequestBuilder<?> requestBuilder, Consumer<T> consumer) {
+        this.intervalInSeconds = intervalInSeconds;
+        this.requestBuilder = requestBuilder;
+        this.resultConsumer = consumer;
+    }
+    /**
+     * @param exceptionHandler BiConsumer to handle exceptions which are not handled in {@link RepeatingRequestTask#handleTornError}
+     */
+    public RepeatingRequestTask<T> handleException(BiConsumer<Exception, RepeatingRequestTask<T>> exceptionHandler) {
+        this.exceptionHandler = exceptionHandler;
+        return this;
+    }
+
+    /**
+     * @param tornErrorHandler handle {@link TornApiErrorException}
+     */
+    public RepeatingRequestTask<T> handleTornError(BiConsumer<TornError, RepeatingRequestTask<T>> tornErrorHandler) {
+        this.tornErrorHandler = tornErrorHandler;
+        return this;
+    }
+
+    /**
+     * @param requestLimitReachedHandler handle {@link RequestLimitReachedException}
+     */
+    public RepeatingRequestTask<T> handleRequestLimitReached(Consumer<RepeatingRequestTask<T>> requestLimitReachedHandler) {
+        this.requestLimitReachedHandler = requestLimitReachedHandler;
+        return this;
+    }
+
+    protected RepeatingRequestTask<T> withMapping(Function<JsonNode, T> mapping) {
+        this.mapping = mapping;
+        return this;
+    }
+
+    public RepeatingRequestTask<T> start() {
+        scheduledFuture = scheduler.scheduleAtFixedRate(() -> {
+            try {
+                if (requestBuilder.getTornApi().hasAutomaticKeyConsumption()) requestBuilder.consumeKey();
+
+                final JsonNode result = requestBuilder.fetch();
+                if (resultConsumer != null) {
+                    resultConsumer.accept(mapping.apply(result));
+                }
+            } catch (TornApiErrorException e) {
+                if (tornErrorHandler != null) {
+                    tornErrorHandler.accept(e.getTornError(), this);
+                }
+            } catch (RequestLimitReachedException e) {
+                if (requestLimitReachedHandler != null) {
+                    requestLimitReachedHandler.accept(this);
+                }
+            } catch (IOException | InterruptedException | TornHttpException  e) {
+                if (exceptionHandler == null) {
+                    stop();
+                    Thread.currentThread().interrupt();
+                } else {
+                    exceptionHandler.accept(e, this);
+                }
+            }
+        }, 0, intervalInSeconds, TimeUnit.SECONDS);
+
+        return this;
+    }
+
+    public void stop() {
+        if (scheduledFuture != null && !scheduledFuture.isCancelled()) {
+            scheduledFuture.cancel(true);
+        }
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/RepeatingRequestTask.java
+++ b/src/main/java/eu/tornplayground/tornapi/RepeatingRequestTask.java
@@ -36,7 +36,7 @@ public class RepeatingRequestTask<T> {
     }
 
     /**
-     * @param tornErrorHandler handle {@link TornApiErrorException}
+     * @param tornErrorHandler handle {@link TornErrorException}
      */
     public RepeatingRequestTask<T> handleTornError(BiConsumer<TornError, RepeatingRequestTask<T>> tornErrorHandler) {
         this.tornErrorHandler = tornErrorHandler;
@@ -65,7 +65,7 @@ public class RepeatingRequestTask<T> {
                     if (resultConsumer != null) {
                         resultConsumer.accept(mapping.apply(result));
                     }
-                } catch (TornApiErrorException e) {
+                } catch (TornErrorException e) {
                     if (tornErrorHandler != null) {
                         tornErrorHandler.accept(e.getTornError(), this);
                     }

--- a/src/main/java/eu/tornplayground/tornapi/RequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/RequestBuilder.java
@@ -1,0 +1,216 @@
+package eu.tornplayground.tornapi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.tornplayground.tornapi.connector.TornHttpException;
+import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
+import eu.tornplayground.tornapi.limiter.RequestLimiter;
+import eu.tornplayground.tornapi.mappers.ModelMapper;
+import eu.tornplayground.tornapi.models.TornError;
+import eu.tornplayground.tornapi.selections.Selection;
+import net.moznion.uribuildertiny.URIBuilderTiny;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public abstract class RequestBuilder<T extends Selection> {
+
+
+    private final TornApi tornApi;
+    private final String section;
+
+    private final Set<String> selections = new HashSet<>();
+    private final Map<String, Object> parameters = new HashMap<>();
+
+    private String key;
+    private String id;
+    private String comment;
+
+    private boolean usedProvider = false;
+    private boolean throwTornError = false;
+
+    protected RequestBuilder(TornApi tornApi, String section) {
+        this.tornApi = tornApi;
+        this.section = section;
+        this.comment = tornApi.getComment();
+    }
+
+    protected TornApi getTornApi() {
+        return tornApi;
+    }
+
+    /**
+     * Set the id for the connection.
+     */
+    public RequestBuilder<T> id(long id) {
+        return id(Long.toString(id));
+    }
+
+    /**
+     * Set the id for the connection.
+     */
+    public RequestBuilder<T> id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Add selections to the connection.
+     */
+    @SafeVarargs
+    public final RequestBuilder<T> withSelections(T... selections) {
+        this.selections.addAll(Arrays.stream(selections)
+                .map(Selection::getSelection)
+                .collect(Collectors.toList()));
+        return this;
+    }
+
+    /**
+     * Add selections to the connection.
+     */
+    public RequestBuilder<T> withSelections(String... selections) {
+        this.selections.addAll(List.of(selections));
+        return this;
+    }
+
+    /**
+     * Add selections to the connection.
+     */
+    public RequestBuilder<T> withParameter(String key, Object value) {
+        this.parameters.put(key, value);
+        return this;
+    }
+
+    /**
+     * Add selections to the connection.
+     */
+    public RequestBuilder<T> withComment(String comment) {
+        this.comment = comment;
+        return this;
+    }
+
+    /**
+     * Set key to be used by the connection.
+     */
+    public RequestBuilder<T> withKey(String key) {
+        this.key = key;
+        usedProvider = false;
+        return this;
+    }
+
+    /**
+     * Consume a key using the KeyProvider.
+     */
+    public RequestBuilder<T> consumeKey() {
+        Objects.requireNonNull(tornApi.getKeyProvider());
+
+        this.key = tornApi.getKeyProvider().next();
+        usedProvider = true;
+        return this;
+    }
+
+    /**
+     * Ignore Torn API errors and return the response as is.
+     */
+    public RequestBuilder<T> throwTornError() {
+        this.throwTornError = true;
+        return this;
+    }
+
+    protected URI buildUri() {
+        Objects.requireNonNull(key);
+
+        URIBuilderTiny uriBuilder = new URIBuilderTiny()
+                .setScheme("https")
+                .setHost("api.torn.com")
+                .setPaths(section);
+
+        if (id != null) uriBuilder.appendPaths(id);
+
+        uriBuilder.setQueryParameters(parameters);
+        if (comment != null) uriBuilder.addQueryParameter("comment", comment);
+        uriBuilder.addQueryParameter("selections", String.join(",", selections));
+        uriBuilder.addQueryParameter("key", key);
+
+        return uriBuilder.build();
+    }
+
+    public JsonNode fetch() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+        RequestData request = new RequestData(key, id, section, selections, parameters);
+
+        if (tornApi.getResponseCache() != null && tornApi.getResponseCache().contains(request.cacheHash())) {
+            return tornApi.getResponseCache().get(request.cacheHash());
+        }
+
+        if (tornApi.hasAutomaticKeyConsumption()) {
+            consumeKey();
+        }
+
+        if (tornApi.getRequestLimiter() != null) {
+            tornApi.getRequestLimiter().handleRequest(key);
+        }
+
+        URI uri = buildUri();
+
+        JsonNode result = tornApi.getConnector().connect(uri.toString());
+
+        if (throwTornError && ModelMapper.hasError(result)) {
+            TornError tornError = ModelMapper.ofError(result);
+            throw new TornApiErrorException(tornError);
+        }
+
+        if (tornApi.getResponseCache() != null && !ModelMapper.hasError(result)) {
+            tornApi.getResponseCache().put(request.cacheHash(), result);
+        }
+
+        if (usedProvider) {
+            tornApi.getKeyProvider().listener(request, result);
+        }
+
+        return result;
+    }
+
+    protected   <V> V fetch(T selection, Function<JsonNode, V> mapping) throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        withSelections(selection);
+        return mapping.apply(fetch());
+    }
+
+    public CompletableFuture<JsonNode> fetchAsync() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return fetch();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new CompletionException(e);
+            } catch (IOException | TornHttpException | RequestLimitReachedException | TornApiErrorException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    protected <V> CompletableFuture<V> fetchAsync(T selection, Function<JsonNode, V> mapping) {
+        withSelections(selection);
+        return fetchAsync().thenApply(mapping);
+    }
+
+    /**
+     * Repeatedly fetch data from the API and consume it.
+     * Does not ignore the {@link RequestLimiter}, if one is configured.
+     *
+     * @param intervalInSeconds in milliseconds
+     */
+    public RepeatingRequestTask<JsonNode> repeating(long intervalInSeconds, Consumer<JsonNode> consumer) {
+        return new RepeatingRequestTask<>(intervalInSeconds, this, consumer);
+    }
+
+    protected <V> RepeatingRequestTask<V> repeating(T selection, long intervalInSeconds, Function<JsonNode, V> mapping, Consumer<V> consumer) {
+        withSelections(selection);
+        return new RepeatingRequestTask<V>(intervalInSeconds, this, consumer)
+                .withMapping(mapping);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/RequestData.java
+++ b/src/main/java/eu/tornplayground/tornapi/RequestData.java
@@ -1,0 +1,51 @@
+package eu.tornplayground.tornapi;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class RequestData {
+
+    private final String key;
+    private final String id;
+    private final String section;
+
+    private final Set<String> selections;
+    private final Map<String, Object> parameters;
+
+    public RequestData(String key, String id, String section, Set<String> selections, Map<String, Object> parameters) {
+        this.key = key;
+        this.id = id;
+        this.section = section;
+        this.selections = selections;
+        this.parameters = parameters;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSection() {
+        return section;
+    }
+
+    public Set<String> getSelections() {
+        return selections;
+    }
+
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+
+    /**
+     * Hash the request data for caching.
+     * Excludes the parameters as they are not used for caching.
+     */
+    public int cacheHash() {
+        return Objects.hash(key, id, section, selections);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/TornApi.java
+++ b/src/main/java/eu/tornplayground/tornapi/TornApi.java
@@ -1,45 +1,45 @@
 package eu.tornplayground.tornapi;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import eu.tornplayground.tornapi.cache.DefaultResponseCache;
 import eu.tornplayground.tornapi.cache.ResponseCache;
 import eu.tornplayground.tornapi.connector.ApiConnector;
-import eu.tornplayground.tornapi.connector.TornHttpException;
 import eu.tornplayground.tornapi.keyprovider.KeyProvider;
 import eu.tornplayground.tornapi.limiter.DefaultRequestLimiter;
-import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
 import eu.tornplayground.tornapi.limiter.RequestLimiter;
-import eu.tornplayground.tornapi.mappers.ModelMapper;
-import eu.tornplayground.tornapi.selections.*;
-import net.moznion.uribuildertiny.URIBuilderTiny;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
+import eu.tornplayground.tornapi.requestbuilder.*;
 
 public class TornApi {
-
     private final ApiConnector connector;
     private final KeyProvider keyProvider;
-    private String defaultComment;
     private RequestLimiter requestLimiter;
     private ResponseCache responseCache;
+    private String comment;
+    private boolean automaticKeyConsumption = false;
 
     public TornApi(ApiConnector connector, KeyProvider keyProvider) {
         this.connector = connector;
         this.keyProvider = keyProvider;
     }
 
-    public TornApi(ApiConnector connector) {
-        this(connector, null);
+    protected ApiConnector getConnector() {
+        return connector;
+    }
+
+    protected KeyProvider getKeyProvider() {
+        return keyProvider;
+    }
+
+    protected RequestLimiter getRequestLimiter() {
+        return requestLimiter;
     }
 
     public TornApi withRequestLimiter(RequestLimiter requestLimiter) {
         this.requestLimiter = requestLimiter;
         return this;
+    }
+
+    protected ResponseCache getResponseCache() {
+        return responseCache;
     }
 
     /**
@@ -49,9 +49,8 @@ public class TornApi {
         return withRequestLimiter(new DefaultRequestLimiter());
     }
 
-
-    public TornApi withResponseCache(ResponseCache cache) {
-        this.responseCache = cache;
+    public TornApi withResponseCache(ResponseCache responseCache) {
+        this.responseCache = responseCache;
         return this;
     }
 
@@ -63,234 +62,105 @@ public class TornApi {
         return this;
     }
 
-    public String getDefaultComment() {
-        return defaultComment;
+    protected String getComment() {
+        return comment;
     }
 
-    public void setDefaultComment(String defaultComment) {
-        this.defaultComment = defaultComment;
+    public TornApi withComment(String comment) {
+        this.comment = comment;
+        return this;
     }
 
-    public <T extends Selection> ApiSection<T> forCategory(String category, @SuppressWarnings("unused") Class<T> selectionType) {
-        return new ApiSection<>(category, defaultComment);
+    protected boolean hasAutomaticKeyConsumption() {
+        return automaticKeyConsumption;
     }
 
-    public ApiSection<UserSelections> forUsers() {
-        return forCategory("user", UserSelections.class);
+    public TornApi withAutomaticKeyConsumption(boolean enabled) {
+        this.automaticKeyConsumption = enabled;
+        return this;
     }
 
-    public ApiSection<PropertiesSelections> forProperties() {
-        return forCategory("property", PropertiesSelections.class);
+    public UserRequestBuilder forUser() {
+        return new UserRequestBuilder(this);
     }
 
-    public ApiSection<FactionSelections> forFaction() {
-        return forCategory("faction", FactionSelections.class);
+    public UserAsyncRequestBuilder forUserAsync() {
+        return new UserAsyncRequestBuilder(this);
     }
 
-    public ApiSection<CompanySelections> forCompany() {
-        return forCategory("company", CompanySelections.class);
+    public UserRepeatingRequestBuilder forUserRepeating() {
+        return new UserRepeatingRequestBuilder(this);
     }
 
-    public ApiSection<ItemMarketSelections> forMarket() {
-        return forCategory("market", ItemMarketSelections.class);
+    public PropertyRequestBuilder forProperties() {
+        return new PropertyRequestBuilder(this);
     }
 
-    public ApiSection<TornSelections> forTorn() {
-        return forCategory("torn", TornSelections.class);
+    public PropertyAsyncRequestBuilder forPropertiesAsync() {
+        return new PropertyAsyncRequestBuilder(this);
     }
 
-    public ApiSection<KeySelections> forKey() {
-        return forCategory("key", KeySelections.class);
+    public PropertyRepeatingRequestBuilder forPropertiesRepeating() {
+        return new PropertyRepeatingRequestBuilder(this);
     }
 
-    public static class RequestData {
-
-        private final String key;
-        private final String id;
-        private final String section;
-
-        private final Set<String> selections;
-        private final Map<String, Object> parameters;
-
-        public RequestData(String key, String id, String section, Set<String> selections, Map<String, Object> parameters) {
-            this.key = key;
-            this.id = id;
-            this.section = section;
-            this.selections = selections;
-            this.parameters = parameters;
-        }
-
-        public String getKey() {
-            return key;
-        }
-
-        public String getId() {
-            return id;
-        }
-
-        public String getSection() {
-            return section;
-        }
-
-        public Set<String> getSelections() {
-            return selections;
-        }
-
-        public Map<String, Object> getParameters() {
-            return parameters;
-        }
-
-        /**
-         * Hash the request data for caching.
-         * Excludes the parameters as they are not used for caching.
-         */
-        public int cacheHash() {
-            return Objects.hash(key, id, section, selections);
-        }
+    public FactionRequestBuilder forFaction() {
+        return new FactionRequestBuilder(this);
     }
 
-    public class ApiSection<T extends Selection> {
+    public FactionAsyncRequestBuilder forFactionAsync() {
+        return new FactionAsyncRequestBuilder(this);
+    }
 
-        private final String section;
+    public FactionRepeatingRequestBuilder forFactionRepeating() {
+        return new FactionRepeatingRequestBuilder(this);
+    }
 
-        private final Set<String> selections = new HashSet<>();
-        private final Map<String, Object> parameters = new HashMap<>();
+    public CompanyRequestBuilder forCompany() {
+        return new CompanyRequestBuilder(this);
+    }
 
-        private String key;
-        private String id;
-        private String comment;
+    public CompanyAsyncRequestBuilder forCompanyAsync() {
+        return new CompanyAsyncRequestBuilder(this);
+    }
 
-        private boolean usedProvider = false;
+    public CompanyRepeatingRequestBuilder forCompanyRepeating() {
+        return new CompanyRepeatingRequestBuilder(this);
+    }
 
-        private ApiSection(String section, String defaultComment) {
-            this.section = section;
-            this.comment = defaultComment;
-        }
+    public MarketRequestBuilder forMarket() {
+        return new MarketRequestBuilder(this);
+    }
 
-        /**
-         * Set the id for the connection.
-         */
-        public ApiSection<T> id(long id) {
-            return id(Long.toString(id));
-        }
+    public MarketAsyncRequestBuilder forMarketAsync() {
+        return new MarketAsyncRequestBuilder(this);
+    }
 
-        /**
-         * Set the id for the connection.
-         */
-        public ApiSection<T> id(String id) {
-            this.id = id;
-            return this;
-        }
+    public MarketRepeatingRequestBuilder forMarketRepeating() {
+        return new MarketRepeatingRequestBuilder(this);
+    }
 
-        /**
-         * Add selections to the connection.
-         */
-        @SafeVarargs
-        public final ApiSection<T> withSelections(T... selections) {
-            this.selections.addAll(Arrays.stream(selections)
-                    .map(Selection::getSelection)
-                    .collect(Collectors.toList()));
-            return this;
-        }
+    public TornRequestBuilder forTorn() {
+        return new TornRequestBuilder(this);
+    }
 
-        /**
-         * Add selections to the connection.
-         */
-        public ApiSection<T> withSelections(String... selections) {
-            this.selections.addAll(List.of(selections));
-            return this;
-        }
+    public TornAsyncRequestBuilder forTornAsync() {
+        return new TornAsyncRequestBuilder(this);
+    }
 
-        /**
-         * Add selections to the connection.
-         */
-        public ApiSection<T> withParameter(String key, Object value) {
-            this.parameters.put(key, value);
-            return this;
-        }
+    public TornRepeatingRequestBuilder forTornRepeating() {
+        return new TornRepeatingRequestBuilder(this);
+    }
 
-        /**
-         * Add selections to the connection.
-         */
-        public ApiSection<T> withComment(String comment) {
-            this.comment = comment;
-            return this;
-        }
+    public KeyRequestBuilder forKey() {
+        return new KeyRequestBuilder(this);
+    }
 
-        /**
-         * Set key to be used by the connection.
-         */
-        public ApiSection<T> key(String key) {
-            this.key = key;
-            usedProvider = false;
-            return this;
-        }
+    public KeyAsyncRequestBuilder forKeyAsync() {
+        return new KeyAsyncRequestBuilder(this);
+    }
 
-        /**
-         * Consume a key using the KeyProvider.
-         */
-        public ApiSection<T> consumeKey() {
-            Objects.requireNonNull(keyProvider);
-
-            this.key = keyProvider.next();
-            usedProvider = true;
-            return this;
-        }
-
-        private URI buildUri() {
-            Objects.requireNonNull(key);
-
-            URIBuilderTiny uriBuilder = new URIBuilderTiny()
-                    .setScheme("https")
-                    .setHost("api.torn.com")
-                    .setPaths(section);
-
-            if (id != null) uriBuilder.appendPaths(id);
-
-            uriBuilder.setQueryParameters(parameters);
-            if (comment != null) uriBuilder.addQueryParameter("comment", comment);
-            uriBuilder.addQueryParameter("selections", String.join(",", selections));
-            uriBuilder.addQueryParameter("key", key);
-
-            return uriBuilder.build();
-        }
-
-        public JsonNode fetch() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException {
-            RequestData request = new RequestData(key, id, section, selections, parameters);
-
-            if (responseCache != null && responseCache.contains(request.cacheHash())) {
-                return responseCache.get(request.cacheHash());
-            }
-
-            if (requestLimiter != null) {
-                requestLimiter.handleRequest(key);
-            }
-
-            URI uri = buildUri();
-            JsonNode result = connector.connect(uri.toString());
-
-            if (responseCache != null && !ModelMapper.hasError(result)) {
-                responseCache.put(request.cacheHash(), result);
-            }
-
-            if (usedProvider) {
-                keyProvider.listener(request, result);
-            }
-
-            return result;
-        }
-
-        public CompletableFuture<JsonNode> fetchAsync() {
-            return CompletableFuture.supplyAsync(() -> {
-                try {
-                    return fetch();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new CompletionException(e);
-                } catch (IOException | TornHttpException | RequestLimitReachedException e) {
-                    throw new CompletionException(e);
-                }
-            });
-        }
+    public KeyRepeatingRequestBuilder forKeyRepeating() {
+        return new KeyRepeatingRequestBuilder(this);
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/TornApi.java
+++ b/src/main/java/eu/tornplayground/tornapi/TornApi.java
@@ -252,8 +252,10 @@ public class TornApi {
             return CompletableFuture.supplyAsync(() -> {
                 try {
                     return fetch();
-                } catch (IOException | InterruptedException | TornHttpException | RequestLimitReachedException e) {
+                } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                    throw new CompletionException(e);
+                } catch (IOException | TornHttpException | RequestLimitReachedException e) {
                     throw new CompletionException(e);
                 }
             });

--- a/src/main/java/eu/tornplayground/tornapi/TornApiErrorException.java
+++ b/src/main/java/eu/tornplayground/tornapi/TornApiErrorException.java
@@ -1,0 +1,17 @@
+package eu.tornplayground.tornapi;
+
+import eu.tornplayground.tornapi.models.TornError;
+
+public class TornApiErrorException extends Exception{
+
+    private final TornError tornError;
+
+    public TornApiErrorException(TornError tornError) {
+        super(tornError.getError());
+        this.tornError = tornError;
+    }
+
+    public TornError getTornError() {
+        return tornError;
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/TornErrorException.java
+++ b/src/main/java/eu/tornplayground/tornapi/TornErrorException.java
@@ -2,11 +2,11 @@ package eu.tornplayground.tornapi;
 
 import eu.tornplayground.tornapi.models.TornError;
 
-public class TornApiErrorException extends Exception{
+public class TornErrorException extends Exception{
 
     private final TornError tornError;
 
-    public TornApiErrorException(TornError tornError) {
+    public TornErrorException(TornError tornError) {
         super(tornError.getError());
         this.tornError = tornError;
     }

--- a/src/main/java/eu/tornplayground/tornapi/keyprovider/KeyProvider.java
+++ b/src/main/java/eu/tornplayground/tornapi/keyprovider/KeyProvider.java
@@ -1,13 +1,13 @@
 package eu.tornplayground.tornapi.keyprovider;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.RequestData;
 
 public interface KeyProvider {
 
     String next();
 
-    default void listener(TornApi.RequestData request, JsonNode data) {
+    default void listener(RequestData request, JsonNode data) {
     }
 
 }

--- a/src/main/java/eu/tornplayground/tornapi/keyprovider/MultiKeyProvider.java
+++ b/src/main/java/eu/tornplayground/tornapi/keyprovider/MultiKeyProvider.java
@@ -2,20 +2,30 @@ package eu.tornplayground.tornapi.keyprovider;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Queue;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 public class MultiKeyProvider implements KeyProvider {
 
     private final LinkedList<String> keys;
+    private int currentKeyIndex = 0;
 
     public MultiKeyProvider(String... keys) {
         this.keys = new LinkedList<>(List.of(keys));
     }
 
     @Override
-    public String next() {
-        final String nextKey = keys.pollFirst();
-        keys.add(nextKey);
+    public synchronized String next() {
+        if (currentKeyIndex >= keys.size()) {
+            currentKeyIndex = 0;
+        }
+
+        final String nextKey = keys.get(currentKeyIndex++);
+
+        notifyAll();
+
         return nextKey;
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/limiter/DefaultRequestLimiter.java
+++ b/src/main/java/eu/tornplayground/tornapi/limiter/DefaultRequestLimiter.java
@@ -1,0 +1,11 @@
+package eu.tornplayground.tornapi.limiter;
+
+/**
+ * Default implementation of {@link RequestLimiter} with a limit of 100 requests per minute per API key.
+ * That's the default limit for the Torn API.
+ */
+public class DefaultRequestLimiter extends RequestLimiter {
+    public DefaultRequestLimiter() {
+        super((short) 100, 60);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/limiter/RequestLimitReachedException.java
+++ b/src/main/java/eu/tornplayground/tornapi/limiter/RequestLimitReachedException.java
@@ -1,0 +1,7 @@
+package eu.tornplayground.tornapi.limiter;
+
+public class RequestLimitReachedException extends RuntimeException {
+    public RequestLimitReachedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/limiter/RequestLimitReachedException.java
+++ b/src/main/java/eu/tornplayground/tornapi/limiter/RequestLimitReachedException.java
@@ -1,6 +1,6 @@
 package eu.tornplayground.tornapi.limiter;
 
-public class RequestLimitReachedException extends RuntimeException {
+public class RequestLimitReachedException extends Exception {
     public RequestLimitReachedException(String message) {
         super(message);
     }

--- a/src/main/java/eu/tornplayground/tornapi/limiter/RequestLimiter.java
+++ b/src/main/java/eu/tornplayground/tornapi/limiter/RequestLimiter.java
@@ -1,0 +1,49 @@
+package eu.tornplayground.tornapi.limiter;
+
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * Limits the number of requests per given time frame per API key.
+ */
+public class RequestLimiter {
+    private final Map<String, Deque<Long>> keyTimestampMap = new ConcurrentHashMap<>();
+
+    private final short maxRequests;
+    private final int timeFrameInMilliseconds;
+
+    public RequestLimiter(short maxRequests, int seconds) {
+        this.maxRequests = maxRequests;
+        this.timeFrameInMilliseconds = seconds * 1000;
+
+        if (maxRequests / seconds > 100 / 60) {
+            throw new IllegalArgumentException("The rate limit is too high. The maximum rate limit is 100 requests per minute. Due to torn limitations.");
+        }
+    }
+
+    public long getMillisecondsUntilNextRequest(String apiKey) {
+        if (hasLimitReached(apiKey)) {
+            return 0;
+        }
+
+        long currentMilliseconds = System.currentTimeMillis();
+        Deque<Long> timestamps = keyTimestampMap.computeIfAbsent(apiKey, k -> new ConcurrentLinkedDeque<>());
+
+        @SuppressWarnings("ConstantConditions")
+        long oldestTimestamp = timestamps.peekFirst(); // should actually never be null
+        long timeUntilTimestampExpires = timeFrameInMilliseconds - (currentMilliseconds - oldestTimestamp);
+        return Math.max(timeUntilTimestampExpires, 0);
+    }
+
+    public boolean hasLimitReached(String apiKey) {
+        Deque<Long> timestamps = keyTimestampMap.computeIfAbsent(apiKey, k -> new ConcurrentLinkedDeque<>());
+        timestamps.removeIf(timestamp -> timestamp + timeFrameInMilliseconds < System.currentTimeMillis());
+        return timestamps.size() >= maxRequests;
+    }
+
+    public void registerRequest(String apiKey, long timestamp) {
+        keyTimestampMap.computeIfAbsent(apiKey, k -> new ConcurrentLinkedDeque<>()).add(timestamp);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyAsyncRequestBuilder.java
@@ -8,4 +8,10 @@ public class CompanyAsyncRequestBuilder extends RequestBuilder<CompanySelections
     public CompanyAsyncRequestBuilder(TornApi tornApi) {
         super(tornApi, "company");
     }
+
+    @Override
+    public CompanyAsyncRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyAsyncRequestBuilder.java
@@ -1,0 +1,11 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.selections.CompanySelections;
+
+public class CompanyAsyncRequestBuilder extends RequestBuilder<CompanySelections> {
+    public CompanyAsyncRequestBuilder(TornApi tornApi) {
+        super(tornApi, "company");
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyAsyncRequestBuilder.java
@@ -10,8 +10,8 @@ public class CompanyAsyncRequestBuilder extends RequestBuilder<CompanySelections
     }
 
     @Override
-    public CompanyAsyncRequestBuilder throwTornError() {
-        super.throwTornError();
+    public CompanyAsyncRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRepeatingRequestBuilder.java
@@ -8,4 +8,10 @@ public class CompanyRepeatingRequestBuilder extends RequestBuilder<CompanySelect
     public CompanyRepeatingRequestBuilder(TornApi tornApi) {
         super(tornApi, "company");
     }
+
+    @Override
+    public CompanyRepeatingRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRepeatingRequestBuilder.java
@@ -1,0 +1,11 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.selections.CompanySelections;
+
+public class CompanyRepeatingRequestBuilder extends RequestBuilder<CompanySelections> {
+    public CompanyRepeatingRequestBuilder(TornApi tornApi) {
+        super(tornApi, "company");
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRepeatingRequestBuilder.java
@@ -10,8 +10,8 @@ public class CompanyRepeatingRequestBuilder extends RequestBuilder<CompanySelect
     }
 
     @Override
-    public CompanyRepeatingRequestBuilder throwTornError() {
-        super.throwTornError();
+    public CompanyRepeatingRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRequestBuilder.java
@@ -1,0 +1,11 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.selections.CompanySelections;
+
+public class CompanyRequestBuilder extends RequestBuilder<CompanySelections> {
+    public CompanyRequestBuilder(TornApi tornApi) {
+        super(tornApi, "company");
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRequestBuilder.java
@@ -10,8 +10,8 @@ public class CompanyRequestBuilder extends RequestBuilder<CompanySelections> {
     }
 
     @Override
-    public CompanyRequestBuilder throwTornError() {
-        super.throwTornError();
+    public CompanyRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRequestBuilder.java
@@ -8,4 +8,10 @@ public class CompanyRequestBuilder extends RequestBuilder<CompanySelections> {
     public CompanyRequestBuilder(TornApi tornApi) {
         super(tornApi, "company");
     }
+
+    @Override
+    public CompanyRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionAsyncRequestBuilder.java
@@ -14,6 +14,12 @@ public class FactionAsyncRequestBuilder extends RequestBuilder<FactionSelections
         super(tornApi, "faction");
     }
 
+    @Override
+    public FactionAsyncRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
      public CompletableFuture<FactionBasic> fetchBasic() {
         return fetchAsync(FactionSelections.BASIC, FactionMapper::ofBasic);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionAsyncRequestBuilder.java
@@ -1,0 +1,36 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.FactionMapper;
+import eu.tornplayground.tornapi.models.faction.*;
+import eu.tornplayground.tornapi.selections.FactionSelections;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class FactionAsyncRequestBuilder extends RequestBuilder<FactionSelections> {
+    public FactionAsyncRequestBuilder(TornApi tornApi) {
+        super(tornApi, "faction");
+    }
+
+     public CompletableFuture<FactionBasic> fetchBasic() {
+        return fetchAsync(FactionSelections.BASIC, FactionMapper::ofBasic);
+    }
+
+     public CompletableFuture<List<FactionAttacks>> fetchAttacks() {
+        return fetchAsync(FactionSelections.ATTACKS, FactionMapper::ofAttacks);
+    }
+
+     public CompletableFuture<List<FactionAttacksFull>> fetchAttacksFull() {
+        return fetchAsync(FactionSelections.ATTACKSFULL, FactionMapper::ofAttacksFull);
+    }
+
+     public CompletableFuture<List<RankedWar>> fetchRankedWars() {
+        return fetchAsync(FactionSelections.RANKEDWARS, FactionMapper::ofRankedWar);
+    }
+
+     public CompletableFuture<Chain> fetchChain() {
+        return fetchAsync(FactionSelections.CHAIN, FactionMapper::ofChain);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionAsyncRequestBuilder.java
@@ -15,8 +15,8 @@ public class FactionAsyncRequestBuilder extends RequestBuilder<FactionSelections
     }
 
     @Override
-    public FactionAsyncRequestBuilder throwTornError() {
-        super.throwTornError();
+    public FactionAsyncRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRepeatingRequestBuilder.java
@@ -1,0 +1,37 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RepeatingRequestTask;
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.FactionMapper;
+import eu.tornplayground.tornapi.models.faction.*;
+import eu.tornplayground.tornapi.selections.FactionSelections;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public class FactionRepeatingRequestBuilder extends RequestBuilder<FactionSelections> {
+    public FactionRepeatingRequestBuilder(TornApi tornApi) {
+        super(tornApi, "faction");
+    }
+
+     public RepeatingRequestTask<FactionBasic> repeatBasic(int intervalInSeconds, Consumer<FactionBasic> consumer) {
+        return repeating(FactionSelections.BASIC, intervalInSeconds,FactionMapper::ofBasic, consumer);
+    }
+
+     public RepeatingRequestTask<List<FactionAttacks>> repeatAttacks(int intervalInSeconds, Consumer<List<FactionAttacks>> consumer) {
+        return repeating(FactionSelections.ATTACKS, intervalInSeconds,FactionMapper::ofAttacks, consumer);
+    }
+
+     public RepeatingRequestTask<List<FactionAttacksFull>> repeatAttacksFull(int intervalInSeconds, Consumer<List<FactionAttacksFull>> consumer) {
+        return repeating(FactionSelections.ATTACKSFULL, intervalInSeconds,FactionMapper::ofAttacksFull, consumer);
+    }
+
+     public RepeatingRequestTask<List<RankedWar>> repeatRankedWars(int intervalInSeconds, Consumer<List<RankedWar>> consumer) {
+        return repeating(FactionSelections.RANKEDWARS, intervalInSeconds,FactionMapper::ofRankedWar, consumer);
+    }
+
+     public RepeatingRequestTask<Chain> repeatChain(int intervalInSeconds, Consumer<Chain> consumer) {
+        return repeating(FactionSelections.CHAIN, intervalInSeconds,FactionMapper::ofChain, consumer);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRepeatingRequestBuilder.java
@@ -16,8 +16,8 @@ public class FactionRepeatingRequestBuilder extends RequestBuilder<FactionSelect
     }
 
     @Override
-    public FactionRepeatingRequestBuilder throwTornError() {
-        super.throwTornError();
+    public FactionRepeatingRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRepeatingRequestBuilder.java
@@ -15,6 +15,12 @@ public class FactionRepeatingRequestBuilder extends RequestBuilder<FactionSelect
         super(tornApi, "faction");
     }
 
+    @Override
+    public FactionRepeatingRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
      public RepeatingRequestTask<FactionBasic> repeatBasic(int intervalInSeconds, Consumer<FactionBasic> consumer) {
         return repeating(FactionSelections.BASIC, intervalInSeconds,FactionMapper::ofBasic, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRequestBuilder.java
@@ -17,6 +17,12 @@ public class FactionRequestBuilder extends RequestBuilder<FactionSelections> {
         super(tornApi, "faction");
     }
 
+    @Override
+    public FactionRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public FactionBasic fetchBasic() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
         return fetch(FactionSelections.BASIC, FactionMapper::ofBasic);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRequestBuilder.java
@@ -2,7 +2,7 @@ package eu.tornplayground.tornapi.requestbuilder;
 
 import eu.tornplayground.tornapi.RequestBuilder;
 import eu.tornplayground.tornapi.TornApi;
-import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.TornErrorException;
 import eu.tornplayground.tornapi.connector.TornHttpException;
 import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
 import eu.tornplayground.tornapi.mappers.FactionMapper;
@@ -18,28 +18,28 @@ public class FactionRequestBuilder extends RequestBuilder<FactionSelections> {
     }
 
     @Override
-    public FactionRequestBuilder throwTornError() {
-        super.throwTornError();
+    public FactionRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 
-    public FactionBasic fetchBasic() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public FactionBasic fetchBasic() throws IOException, TornHttpException, TornErrorException, RequestLimitReachedException {
         return fetch(FactionSelections.BASIC, FactionMapper::ofBasic);
     }
 
-    public List<FactionAttacks> fetchAttacks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<FactionAttacks> fetchAttacks() throws IOException, TornHttpException, TornErrorException, RequestLimitReachedException {
         return fetch(FactionSelections.ATTACKS, FactionMapper::ofAttacks);
     }
 
-    public List<FactionAttacksFull> fetchAttacksFull() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<FactionAttacksFull> fetchAttacksFull() throws IOException, TornHttpException, TornErrorException, RequestLimitReachedException {
         return fetch(FactionSelections.ATTACKSFULL, FactionMapper::ofAttacksFull);
     }
 
-    public List<RankedWar> fetchRankedWars() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<RankedWar> fetchRankedWars() throws IOException, TornHttpException, TornErrorException, RequestLimitReachedException {
         return fetch(FactionSelections.RANKEDWARS, FactionMapper::ofRankedWar);
     }
 
-    public Chain fetchChain() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Chain fetchChain() throws IOException, TornHttpException, TornErrorException, RequestLimitReachedException {
         return fetch(FactionSelections.CHAIN, FactionMapper::ofChain);
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRequestBuilder.java
@@ -1,0 +1,39 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.connector.TornHttpException;
+import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
+import eu.tornplayground.tornapi.mappers.FactionMapper;
+import eu.tornplayground.tornapi.models.faction.*;
+import eu.tornplayground.tornapi.selections.FactionSelections;
+
+import java.io.IOException;
+import java.util.List;
+
+public class FactionRequestBuilder extends RequestBuilder<FactionSelections> {
+    public FactionRequestBuilder(TornApi tornApi) {
+        super(tornApi, "faction");
+    }
+
+    public FactionBasic fetchBasic() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(FactionSelections.BASIC, FactionMapper::ofBasic);
+    }
+
+    public List<FactionAttacks> fetchAttacks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(FactionSelections.ATTACKS, FactionMapper::ofAttacks);
+    }
+
+    public List<FactionAttacksFull> fetchAttacksFull() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(FactionSelections.ATTACKSFULL, FactionMapper::ofAttacksFull);
+    }
+
+    public List<RankedWar> fetchRankedWars() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(FactionSelections.RANKEDWARS, FactionMapper::ofRankedWar);
+    }
+
+    public Chain fetchChain() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(FactionSelections.CHAIN, FactionMapper::ofChain);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyAsyncRequestBuilder.java
@@ -1,0 +1,19 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.KeyMapper;
+import eu.tornplayground.tornapi.models.info.KeyInfo;
+import eu.tornplayground.tornapi.selections.KeySelections;
+
+import java.util.concurrent.CompletableFuture;
+
+public class KeyAsyncRequestBuilder extends RequestBuilder<KeySelections> {
+    public KeyAsyncRequestBuilder(TornApi tornApi) {
+        super(tornApi, "key");
+    }
+
+    public CompletableFuture<KeyInfo> fetchInfo() {
+        return fetchAsync(KeySelections.INFO, KeyMapper::ofInfo);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyAsyncRequestBuilder.java
@@ -14,8 +14,8 @@ public class KeyAsyncRequestBuilder extends RequestBuilder<KeySelections> {
     }
 
     @Override
-    public KeyAsyncRequestBuilder throwTornError() {
-        super.throwTornError();
+    public KeyAsyncRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyAsyncRequestBuilder.java
@@ -13,6 +13,12 @@ public class KeyAsyncRequestBuilder extends RequestBuilder<KeySelections> {
         super(tornApi, "key");
     }
 
+    @Override
+    public KeyAsyncRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public CompletableFuture<KeyInfo> fetchInfo() {
         return fetchAsync(KeySelections.INFO, KeyMapper::ofInfo);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRepeatingRequestBuilder.java
@@ -1,0 +1,20 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RepeatingRequestTask;
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.KeyMapper;
+import eu.tornplayground.tornapi.models.info.KeyInfo;
+import eu.tornplayground.tornapi.selections.KeySelections;
+
+import java.util.function.Consumer;
+
+public class KeyRepeatingRequestBuilder extends RequestBuilder<KeySelections> {
+    public KeyRepeatingRequestBuilder(TornApi tornApi) {
+        super(tornApi, "key");
+    }
+
+    public RepeatingRequestTask<KeyInfo> repeatInfo(int intervalInSeconds, Consumer<KeyInfo> consumer) {
+        return repeating(KeySelections.INFO, intervalInSeconds,KeyMapper::ofInfo, consumer);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRepeatingRequestBuilder.java
@@ -14,6 +14,12 @@ public class KeyRepeatingRequestBuilder extends RequestBuilder<KeySelections> {
         super(tornApi, "key");
     }
 
+    @Override
+    public KeyRepeatingRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public RepeatingRequestTask<KeyInfo> repeatInfo(int intervalInSeconds, Consumer<KeyInfo> consumer) {
         return repeating(KeySelections.INFO, intervalInSeconds,KeyMapper::ofInfo, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRepeatingRequestBuilder.java
@@ -15,8 +15,8 @@ public class KeyRepeatingRequestBuilder extends RequestBuilder<KeySelections> {
     }
 
     @Override
-    public KeyRepeatingRequestBuilder throwTornError() {
-        super.throwTornError();
+    public KeyRepeatingRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRequestBuilder.java
@@ -2,7 +2,7 @@ package eu.tornplayground.tornapi.requestbuilder;
 
 import eu.tornplayground.tornapi.RequestBuilder;
 import eu.tornplayground.tornapi.TornApi;
-import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.TornErrorException;
 import eu.tornplayground.tornapi.connector.TornHttpException;
 import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
 import eu.tornplayground.tornapi.mappers.KeyMapper;
@@ -17,12 +17,12 @@ public class KeyRequestBuilder extends RequestBuilder<KeySelections> {
     }
 
     @Override
-    public KeyRequestBuilder throwTornError() {
-        super.throwTornError();
+    public KeyRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 
-    public KeyInfo fetchInfo() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public KeyInfo fetchInfo() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(KeySelections.INFO, KeyMapper::ofInfo);
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRequestBuilder.java
@@ -1,0 +1,22 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.connector.TornHttpException;
+import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
+import eu.tornplayground.tornapi.mappers.KeyMapper;
+import eu.tornplayground.tornapi.models.info.KeyInfo;
+import eu.tornplayground.tornapi.selections.KeySelections;
+
+import java.io.IOException;
+
+public class KeyRequestBuilder extends RequestBuilder<KeySelections> {
+    public KeyRequestBuilder(TornApi tornApi) {
+        super(tornApi, "key");
+    }
+
+    public KeyInfo fetchInfo() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(KeySelections.INFO, KeyMapper::ofInfo);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRequestBuilder.java
@@ -16,6 +16,12 @@ public class KeyRequestBuilder extends RequestBuilder<KeySelections> {
         super(tornApi, "key");
     }
 
+    @Override
+    public KeyRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public KeyInfo fetchInfo() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
         return fetch(KeySelections.INFO, KeyMapper::ofInfo);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketAsyncRequestBuilder.java
@@ -1,0 +1,30 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.MarketMapper;
+import eu.tornplayground.tornapi.models.market.MarketItem;
+import eu.tornplayground.tornapi.models.market.PointOrder;
+import eu.tornplayground.tornapi.selections.ItemMarketSelections;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public class MarketAsyncRequestBuilder extends RequestBuilder<ItemMarketSelections> {
+    public MarketAsyncRequestBuilder(TornApi tornApi) {
+        super(tornApi, "market");
+    }
+
+    public CompletableFuture<List<MarketItem>> fetchBazaar(){
+        return fetchAsync(ItemMarketSelections.BAZAAR, MarketMapper::ofBazaar);
+    }
+
+    public CompletableFuture<List<MarketItem>> fetchItemMarket(){
+        return fetchAsync(ItemMarketSelections.ITEMMARKET, MarketMapper::ofItemMarket);
+    }
+
+    public CompletableFuture<Map<Long, PointOrder>> fetchPointsMarket(){
+        return fetchAsync(ItemMarketSelections.POINTSMARKET, MarketMapper::ofPointsMarket);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketAsyncRequestBuilder.java
@@ -16,6 +16,12 @@ public class MarketAsyncRequestBuilder extends RequestBuilder<ItemMarketSelectio
         super(tornApi, "market");
     }
 
+    @Override
+    public MarketAsyncRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public CompletableFuture<List<MarketItem>> fetchBazaar(){
         return fetchAsync(ItemMarketSelections.BAZAAR, MarketMapper::ofBazaar);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketAsyncRequestBuilder.java
@@ -17,8 +17,8 @@ public class MarketAsyncRequestBuilder extends RequestBuilder<ItemMarketSelectio
     }
 
     @Override
-    public MarketAsyncRequestBuilder throwTornError() {
-        super.throwTornError();
+    public MarketAsyncRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRepeatingRequestBuilder.java
@@ -17,6 +17,12 @@ public class MarketRepeatingRequestBuilder extends RequestBuilder<ItemMarketSele
         super(tornApi, "market");
     }
 
+    @Override
+    public MarketRepeatingRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public RepeatingRequestTask<List<MarketItem>> repeatBazaar(int intervalInSeconds, Consumer<List<MarketItem>> consumer) {
         return repeating(ItemMarketSelections.BAZAAR, intervalInSeconds,MarketMapper::ofBazaar, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRepeatingRequestBuilder.java
@@ -18,8 +18,8 @@ public class MarketRepeatingRequestBuilder extends RequestBuilder<ItemMarketSele
     }
 
     @Override
-    public MarketRepeatingRequestBuilder throwTornError() {
-        super.throwTornError();
+    public MarketRepeatingRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRepeatingRequestBuilder.java
@@ -1,0 +1,31 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RepeatingRequestTask;
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.MarketMapper;
+import eu.tornplayground.tornapi.models.market.MarketItem;
+import eu.tornplayground.tornapi.models.market.PointOrder;
+import eu.tornplayground.tornapi.selections.ItemMarketSelections;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class MarketRepeatingRequestBuilder extends RequestBuilder<ItemMarketSelections> {
+    public MarketRepeatingRequestBuilder(TornApi tornApi) {
+        super(tornApi, "market");
+    }
+
+    public RepeatingRequestTask<List<MarketItem>> repeatBazaar(int intervalInSeconds, Consumer<List<MarketItem>> consumer) {
+        return repeating(ItemMarketSelections.BAZAAR, intervalInSeconds,MarketMapper::ofBazaar, consumer);
+    }
+
+    public RepeatingRequestTask<List<MarketItem>> repeatItemMarket(int intervalInSeconds, Consumer<List<MarketItem>> consumer) {
+        return repeating(ItemMarketSelections.ITEMMARKET, intervalInSeconds,MarketMapper::ofItemMarket, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, PointOrder>> repeatPointsMarket(int intervalInSeconds, Consumer<Map<Long, PointOrder>> consumer) {
+        return repeating(ItemMarketSelections.POINTSMARKET, intervalInSeconds,MarketMapper::ofPointsMarket, consumer);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRequestBuilder.java
@@ -1,0 +1,33 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.connector.TornHttpException;
+import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
+import eu.tornplayground.tornapi.mappers.MarketMapper;
+import eu.tornplayground.tornapi.models.market.MarketItem;
+import eu.tornplayground.tornapi.models.market.PointOrder;
+import eu.tornplayground.tornapi.selections.ItemMarketSelections;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class MarketRequestBuilder extends RequestBuilder<ItemMarketSelections> {
+    public MarketRequestBuilder(TornApi tornApi) {
+        super(tornApi, "market");
+    }
+
+    public List<MarketItem> fetchBazaar() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(ItemMarketSelections.BAZAAR, MarketMapper::ofBazaar);
+    }
+
+    public List<MarketItem> fetchItemMarket() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(ItemMarketSelections.ITEMMARKET, MarketMapper::ofItemMarket);
+    }
+
+    public Map<Long, PointOrder> fetchPointsMarket() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(ItemMarketSelections.POINTSMARKET, MarketMapper::ofPointsMarket);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRequestBuilder.java
@@ -2,7 +2,7 @@ package eu.tornplayground.tornapi.requestbuilder;
 
 import eu.tornplayground.tornapi.RequestBuilder;
 import eu.tornplayground.tornapi.TornApi;
-import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.TornErrorException;
 import eu.tornplayground.tornapi.connector.TornHttpException;
 import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
 import eu.tornplayground.tornapi.mappers.MarketMapper;
@@ -20,20 +20,20 @@ public class MarketRequestBuilder extends RequestBuilder<ItemMarketSelections> {
     }
 
     @Override
-    public MarketRequestBuilder throwTornError() {
-        super.throwTornError();
+    public MarketRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 
-    public List<MarketItem> fetchBazaar() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<MarketItem> fetchBazaar() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(ItemMarketSelections.BAZAAR, MarketMapper::ofBazaar);
     }
 
-    public List<MarketItem> fetchItemMarket() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<MarketItem> fetchItemMarket() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(ItemMarketSelections.ITEMMARKET, MarketMapper::ofItemMarket);
     }
 
-    public Map<Long, PointOrder> fetchPointsMarket() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, PointOrder> fetchPointsMarket() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(ItemMarketSelections.POINTSMARKET, MarketMapper::ofPointsMarket);
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRequestBuilder.java
@@ -19,6 +19,12 @@ public class MarketRequestBuilder extends RequestBuilder<ItemMarketSelections> {
         super(tornApi, "market");
     }
 
+    @Override
+    public MarketRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public List<MarketItem> fetchBazaar() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
         return fetch(ItemMarketSelections.BAZAAR, MarketMapper::ofBazaar);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyAsyncRequestBuilder.java
@@ -1,0 +1,11 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.selections.PropertiesSelections;
+
+public class PropertyAsyncRequestBuilder extends RequestBuilder<PropertiesSelections> {
+    public PropertyAsyncRequestBuilder(TornApi tornApi) {
+        super(tornApi, "property");
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyAsyncRequestBuilder.java
@@ -10,8 +10,8 @@ public class PropertyAsyncRequestBuilder extends RequestBuilder<PropertiesSelect
     }
 
     @Override
-    public PropertyAsyncRequestBuilder throwTornError() {
-        super.throwTornError();
+    public PropertyAsyncRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyAsyncRequestBuilder.java
@@ -8,4 +8,10 @@ public class PropertyAsyncRequestBuilder extends RequestBuilder<PropertiesSelect
     public PropertyAsyncRequestBuilder(TornApi tornApi) {
         super(tornApi, "property");
     }
+
+    @Override
+    public PropertyAsyncRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRepeatingRequestBuilder.java
@@ -8,4 +8,10 @@ public class PropertyRepeatingRequestBuilder extends RequestBuilder<PropertiesSe
     public PropertyRepeatingRequestBuilder(TornApi tornApi) {
         super(tornApi, "property");
     }
+
+    @Override
+    public PropertyRepeatingRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRepeatingRequestBuilder.java
@@ -10,8 +10,8 @@ public class PropertyRepeatingRequestBuilder extends RequestBuilder<PropertiesSe
     }
 
     @Override
-    public PropertyRepeatingRequestBuilder throwTornError() {
-        super.throwTornError();
+    public PropertyRepeatingRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRepeatingRequestBuilder.java
@@ -1,0 +1,11 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.selections.PropertiesSelections;
+
+public class PropertyRepeatingRequestBuilder extends RequestBuilder<PropertiesSelections> {
+    public PropertyRepeatingRequestBuilder(TornApi tornApi) {
+        super(tornApi, "property");
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRequestBuilder.java
@@ -8,4 +8,10 @@ public class PropertyRequestBuilder extends RequestBuilder<PropertiesSelections>
     public PropertyRequestBuilder(TornApi tornApi) {
         super(tornApi, "property");
     }
+
+    @Override
+    public PropertyRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRequestBuilder.java
@@ -1,0 +1,11 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.selections.PropertiesSelections;
+
+public class PropertyRequestBuilder extends RequestBuilder<PropertiesSelections> {
+    public PropertyRequestBuilder(TornApi tornApi) {
+        super(tornApi, "property");
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRequestBuilder.java
@@ -10,8 +10,8 @@ public class PropertyRequestBuilder extends RequestBuilder<PropertiesSelections>
     }
 
     @Override
-    public PropertyRequestBuilder throwTornError() {
-        super.throwTornError();
+    public PropertyRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornAsyncRequestBuilder.java
@@ -16,8 +16,8 @@ public class TornAsyncRequestBuilder extends RequestBuilder<TornSelections> {
     }
 
     @Override
-    public TornAsyncRequestBuilder throwTornError() {
-        super.throwTornError();
+    public TornAsyncRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornAsyncRequestBuilder.java
@@ -1,0 +1,41 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.TornMapper;
+import eu.tornplayground.tornapi.models.torn.*;
+import eu.tornplayground.tornapi.selections.TornSelections;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public class TornAsyncRequestBuilder extends RequestBuilder<TornSelections> {
+    public TornAsyncRequestBuilder(TornApi tornApi) {
+        super(tornApi, "torn");
+    }
+
+    public CompletableFuture<Map<Long, CompanyType>> fetchCompanies() {
+        return fetchAsync(TornSelections.COMPANIES, TornMapper::ofCompanies);
+    }
+
+    public CompletableFuture<Map<Long, TornItem>> fetchItems() {
+        return fetchAsync(TornSelections.ITEMS, TornMapper::ofItems);
+    }
+
+    public CompletableFuture<Map<Long, Stock>> fetchStocks() {
+        return fetchAsync(TornSelections.STOCKS, TornMapper::ofStocks);
+    }
+
+    public CompletableFuture<TornStats> fetchStats() {
+        return fetchAsync(TornSelections.STATS, TornMapper::ofStats);
+    }
+
+    public CompletableFuture<Map<String, List<ShopLiftingSecurity>>> fetchShoplifting() {
+        return fetchAsync(TornSelections.SHOPLIFTING, TornMapper::ofShoplifting);
+    }
+
+    public CompletableFuture<PawnShop> fetchPawnShop() {
+        return fetchAsync(TornSelections.PAWNSHOP, TornMapper::ofPawnShop);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornAsyncRequestBuilder.java
@@ -15,6 +15,12 @@ public class TornAsyncRequestBuilder extends RequestBuilder<TornSelections> {
         super(tornApi, "torn");
     }
 
+    @Override
+    public TornAsyncRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public CompletableFuture<Map<Long, CompanyType>> fetchCompanies() {
         return fetchAsync(TornSelections.COMPANIES, TornMapper::ofCompanies);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRepeatingRequestBuilder.java
@@ -16,6 +16,12 @@ public class TornRepeatingRequestBuilder extends RequestBuilder<TornSelections> 
         super(tornApi, "torn");
     }
 
+    @Override
+    public TornRepeatingRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public RepeatingRequestTask<Map<Long, CompanyType>> repeatCompanies(int intervalInSeconds, Consumer<Map<Long, CompanyType>> consumer) {
         return repeating(TornSelections.COMPANIES, intervalInSeconds,TornMapper::ofCompanies, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRepeatingRequestBuilder.java
@@ -1,0 +1,42 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RepeatingRequestTask;
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.TornMapper;
+import eu.tornplayground.tornapi.models.torn.*;
+import eu.tornplayground.tornapi.selections.TornSelections;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class TornRepeatingRequestBuilder extends RequestBuilder<TornSelections> {
+    public TornRepeatingRequestBuilder(TornApi tornApi) {
+        super(tornApi, "torn");
+    }
+
+    public RepeatingRequestTask<Map<Long, CompanyType>> repeatCompanies(int intervalInSeconds, Consumer<Map<Long, CompanyType>> consumer) {
+        return repeating(TornSelections.COMPANIES, intervalInSeconds,TornMapper::ofCompanies, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, TornItem>> repeatItems(int intervalInSeconds, Consumer<Map<Long, TornItem>> consumer) {
+        return repeating(TornSelections.ITEMS, intervalInSeconds,TornMapper::ofItems, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, Stock>> repeatStocks(int intervalInSeconds, Consumer<Map<Long, Stock>> consumer) {
+        return repeating(TornSelections.STOCKS, intervalInSeconds,TornMapper::ofStocks, consumer);
+    }
+
+    public RepeatingRequestTask<TornStats> repeatStats(int intervalInSeconds, Consumer<TornStats> consumer) {
+        return repeating(TornSelections.STATS, intervalInSeconds,TornMapper::ofStats, consumer);
+    }
+
+    public RepeatingRequestTask<Map<String, List<ShopLiftingSecurity>>> repeatShoplifting(int intervalInSeconds, Consumer<Map<String, List<ShopLiftingSecurity>>> consumer) {
+        return repeating(TornSelections.SHOPLIFTING, intervalInSeconds,TornMapper::ofShoplifting, consumer);
+    }
+
+    public RepeatingRequestTask<PawnShop> repeatPawnShop(int intervalInSeconds, Consumer<PawnShop> consumer) {
+        return repeating(TornSelections.PAWNSHOP, intervalInSeconds,TornMapper::ofPawnShop, consumer);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRepeatingRequestBuilder.java
@@ -17,8 +17,8 @@ public class TornRepeatingRequestBuilder extends RequestBuilder<TornSelections> 
     }
 
     @Override
-    public TornRepeatingRequestBuilder throwTornError() {
-        super.throwTornError();
+    public TornRepeatingRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRequestBuilder.java
@@ -2,7 +2,7 @@ package eu.tornplayground.tornapi.requestbuilder;
 
 import eu.tornplayground.tornapi.RequestBuilder;
 import eu.tornplayground.tornapi.TornApi;
-import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.TornErrorException;
 import eu.tornplayground.tornapi.connector.TornHttpException;
 import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
 import eu.tornplayground.tornapi.mappers.TornMapper;
@@ -19,32 +19,32 @@ public class TornRequestBuilder extends RequestBuilder<TornSelections> {
     }
 
     @Override
-    public TornRequestBuilder throwTornError() {
-        super.throwTornError();
+    public TornRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 
-    public Map<Long, CompanyType> fetchCompanies() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, CompanyType> fetchCompanies() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(TornSelections.COMPANIES, TornMapper::ofCompanies);
     }
 
-    public Map<Long, TornItem> fetchItems() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, TornItem> fetchItems() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(TornSelections.ITEMS, TornMapper::ofItems);
     }
 
-    public Map<Long, Stock> fetchStocks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, Stock> fetchStocks() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(TornSelections.STOCKS, TornMapper::ofStocks);
     }
 
-    public TornStats fetchStats() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public TornStats fetchStats() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(TornSelections.STATS, TornMapper::ofStats);
     }
 
-    public Map<String, List<ShopLiftingSecurity>> fetchShoplifting() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<String, List<ShopLiftingSecurity>> fetchShoplifting() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(TornSelections.SHOPLIFTING, TornMapper::ofShoplifting);
     }
 
-    public PawnShop fetchPawnShop() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public PawnShop fetchPawnShop() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(TornSelections.PAWNSHOP, TornMapper::ofPawnShop);
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRequestBuilder.java
@@ -18,6 +18,12 @@ public class TornRequestBuilder extends RequestBuilder<TornSelections> {
         super(tornApi, "torn");
     }
 
+    @Override
+    public TornRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public Map<Long, CompanyType> fetchCompanies() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
         return fetch(TornSelections.COMPANIES, TornMapper::ofCompanies);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRequestBuilder.java
@@ -1,0 +1,44 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.connector.TornHttpException;
+import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
+import eu.tornplayground.tornapi.mappers.TornMapper;
+import eu.tornplayground.tornapi.models.torn.*;
+import eu.tornplayground.tornapi.selections.TornSelections;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class TornRequestBuilder extends RequestBuilder<TornSelections> {
+    public TornRequestBuilder(TornApi tornApi) {
+        super(tornApi, "torn");
+    }
+
+    public Map<Long, CompanyType> fetchCompanies() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(TornSelections.COMPANIES, TornMapper::ofCompanies);
+    }
+
+    public Map<Long, TornItem> fetchItems() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(TornSelections.ITEMS, TornMapper::ofItems);
+    }
+
+    public Map<Long, Stock> fetchStocks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(TornSelections.STOCKS, TornMapper::ofStocks);
+    }
+
+    public TornStats fetchStats() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(TornSelections.STATS, TornMapper::ofStats);
+    }
+
+    public Map<String, List<ShopLiftingSecurity>> fetchShoplifting() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(TornSelections.SHOPLIFTING, TornMapper::ofShoplifting);
+    }
+
+    public PawnShop fetchPawnShop() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(TornSelections.PAWNSHOP, TornMapper::ofPawnShop);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserAsyncRequestBuilder.java
@@ -3,7 +3,6 @@ package eu.tornplayground.tornapi.requestbuilder;
 import eu.tornplayground.tornapi.RequestBuilder;
 import eu.tornplayground.tornapi.TornApi;
 import eu.tornplayground.tornapi.mappers.UserMapper;
-import eu.tornplayground.tornapi.models.Timestamp;
 import eu.tornplayground.tornapi.models.user.*;
 import eu.tornplayground.tornapi.selections.UserSelections;
 
@@ -17,8 +16,8 @@ public class UserAsyncRequestBuilder extends RequestBuilder<UserSelections> {
     }
 
     @Override
-    public UserAsyncRequestBuilder throwTornError() {
-        super.throwTornError();
+    public UserAsyncRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserAsyncRequestBuilder.java
@@ -16,6 +16,12 @@ public class UserAsyncRequestBuilder extends RequestBuilder<UserSelections> {
         super(tornApi, "user");
     }
 
+    @Override
+    public UserAsyncRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public CompletableFuture<List<Ammo>> fetchAmmo() {
         return fetchAsync(UserSelections.AMMO, UserMapper::ofAmmo);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserAsyncRequestBuilder.java
@@ -1,0 +1,170 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.UserMapper;
+import eu.tornplayground.tornapi.models.Timestamp;
+import eu.tornplayground.tornapi.models.user.*;
+import eu.tornplayground.tornapi.selections.UserSelections;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public class UserAsyncRequestBuilder extends RequestBuilder<UserSelections> {
+    public UserAsyncRequestBuilder(TornApi tornApi) {
+        super(tornApi, "user");
+    }
+
+    public CompletableFuture<List<Ammo>> fetchAmmo() {
+        return fetchAsync(UserSelections.AMMO, UserMapper::ofAmmo);
+    }
+
+    public CompletableFuture<Map<Long, Attack>> fetchAttacks() {
+        return fetchAsync(UserSelections.ATTACKS, UserMapper::ofAttacks);
+    }
+
+    public CompletableFuture<Map<Long, Attack>> fetchAttacksFull() {
+        return fetchAsync(UserSelections.ATTACKSFULL, UserMapper::ofAttacks);
+    }
+
+    public CompletableFuture<Bars> fetchBars() {
+        return fetchAsync(UserSelections.BARS, UserMapper::ofBars);
+    }
+
+    public CompletableFuture<Basic> fetchBasic() {
+        return fetchAsync(UserSelections.BASIC, UserMapper::ofBasic);
+    }
+
+    public CompletableFuture<BattleStats> fetchBattleStats() {
+        return fetchAsync(UserSelections.BATTLESTATS, UserMapper::ofBattleStats);
+    }
+
+    public CompletableFuture<List<BazaarItem>> fetchBazaar() {
+        return fetchAsync(UserSelections.BAZAAR, UserMapper::ofBazaar);
+    }
+
+    public CompletableFuture<Cooldowns> fetchCooldowns() {
+        return fetchAsync(UserSelections.COOLDOWNS, UserMapper::ofCooldowns);
+    }
+
+    public CompletableFuture<CriminalRecord> fetchCrimes() {
+        return fetchAsync(UserSelections.CRIMES, UserMapper::ofCrimes);
+    }
+
+    public CompletableFuture<Discord> fetchDiscord() {
+        return fetchAsync(UserSelections.DISCORD, UserMapper::ofDiscord);
+    }
+
+    public CompletableFuture<List<DisplayItem>> fetchDisplay() {
+        return fetchAsync(UserSelections.DISPLAY, UserMapper::ofDisplay);
+    }
+
+    public CompletableFuture<Education> fetchEducation() {
+        return fetchAsync(UserSelections.EDUCATION, UserMapper::ofEducation);
+    }
+
+    public CompletableFuture<Map<Long, Event>> fetchEvents() {
+        return fetchAsync(UserSelections.EVENTS, UserMapper::ofEvents);
+    }
+
+    public CompletableFuture<Gym> fetchGym() {
+        return fetchAsync(UserSelections.GYM, UserMapper::ofGym);
+    }
+
+    public CompletableFuture<Map<String, HOF>> fetchHof() {
+        return fetchAsync(UserSelections.HOF, UserMapper::ofHOF);
+    }
+
+    public CompletableFuture<List<Honor>> fetchHonors() {
+        return fetchAsync(UserSelections.HONORS, UserMapper::ofHonors);
+    }
+
+    public CompletableFuture<Map<String, String>> fetchIcons() {
+        return fetchAsync(UserSelections.ICONS, UserMapper::ofIcons);
+    }
+
+    public CompletableFuture<List<InventoryItem>> fetchInventory() {
+        return fetchAsync(UserSelections.INVENTORY, UserMapper::ofInventory);
+    }
+
+    public CompletableFuture<JobPoints> fetchJobPoints() {
+        return fetchAsync(UserSelections.JOBPOINTS, UserMapper::ofJobPoints);
+    }
+
+    public CompletableFuture<Map<String, Log>> fetchLog() {
+        return fetchAsync(UserSelections.LOG, UserMapper::ofLog);
+    }
+
+    public CompletableFuture<Map<String, Message>> fetchMessages() {
+        return fetchAsync(UserSelections.MESSAGES, UserMapper::ofMessages);
+    }
+
+    public CompletableFuture<Missions> fetchMissions() {
+        return fetchAsync(UserSelections.MISSIONS, UserMapper::ofMissions);
+    }
+
+    public CompletableFuture<Money> fetchMoney() {
+        return fetchAsync(UserSelections.MONEY, UserMapper::ofMoney);
+    }
+
+    public CompletableFuture<Networth> fetchNetWorth() {
+        return fetchAsync(UserSelections.NETWORTH, UserMapper::ofNetworth);
+    }
+
+    public CompletableFuture<Notifications> fetchNotifications() {
+        return fetchAsync(UserSelections.NOTIFICATIONS, UserMapper::ofNotifications);
+    }
+
+    public CompletableFuture<Perks> fetchPerks() {
+        return fetchAsync(UserSelections.PERKS, UserMapper::ofPerks);
+    }
+
+    public CompletableFuture<PersonalStats> fetchPersonalStats() {
+        return fetchAsync(UserSelections.PERSONALSTATS, UserMapper::ofPersonalStats);
+    }
+
+    public CompletableFuture<Profile> fetchProfile() {
+        return fetchAsync(UserSelections.PROFILE, UserMapper::ofProfile);
+    }
+
+    public CompletableFuture<Map<Long, Property>> fetchProperties() {
+        return fetchAsync(UserSelections.PROPERTIES, UserMapper::ofProperties);
+    }
+
+    public CompletableFuture<Refills> fetchRefills() {
+        return fetchAsync(UserSelections.REFILLS, UserMapper::ofRefills);
+    }
+
+    public CompletableFuture<List<Report>> fetchReports() {
+        return fetchAsync(UserSelections.REPORTS, UserMapper::ofReports);
+    }
+
+    public CompletableFuture<Map<Long, Revive>> fetchRevives() {
+        return fetchAsync(UserSelections.REVIVES, UserMapper::ofRevives);
+    }
+
+    public CompletableFuture<Map<Long, Revive>> fetchRevivesFull() {
+        return fetchAsync(UserSelections.REVIVESFULL, UserMapper::ofRevives);
+    }
+
+    public CompletableFuture<Skills> fetchSkills() {
+        return fetchAsync(UserSelections.SKILLS, UserMapper::ofSkills);
+    }
+
+    public CompletableFuture<Map<Long, Stock>> fetchStocks() {
+        return fetchAsync(UserSelections.STOCKS, UserMapper::ofStocks);
+    }
+
+    public CompletableFuture<Travel> fetchTravel() {
+        return fetchAsync(UserSelections.TRAVEL, UserMapper::ofTravel);
+    }
+
+    public CompletableFuture<List<WeaponExperience>> fetchWeaponExp() {
+        return fetchAsync(UserSelections.WEAPONEXP, UserMapper::ofWeaponExp);
+    }
+
+    public CompletableFuture<WorkStats> fetchWorkStats() {
+        return fetchAsync(UserSelections.WORKSTATS, UserMapper::ofWorkStats);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRepeatingRequestBuilder.java
@@ -16,6 +16,12 @@ public class UserRepeatingRequestBuilder extends RequestBuilder<UserSelections> 
         super(tornApi, "user");
     }
 
+    @Override
+    public UserRepeatingRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public RepeatingRequestTask<List<Ammo>> repeatAmmo(int intervalInSeconds, Consumer<List<Ammo>> consumer) {
         return repeating(UserSelections.AMMO, intervalInSeconds,UserMapper::ofAmmo, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRepeatingRequestBuilder.java
@@ -1,0 +1,170 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RepeatingRequestTask;
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.mappers.UserMapper;
+import eu.tornplayground.tornapi.models.user.*;
+import eu.tornplayground.tornapi.selections.UserSelections;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class UserRepeatingRequestBuilder extends RequestBuilder<UserSelections> {
+    public UserRepeatingRequestBuilder(TornApi tornApi) {
+        super(tornApi, "user");
+    }
+
+    public RepeatingRequestTask<List<Ammo>> repeatAmmo(int intervalInSeconds, Consumer<List<Ammo>> consumer) {
+        return repeating(UserSelections.AMMO, intervalInSeconds,UserMapper::ofAmmo, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, Attack>> repeatAttacks(int intervalInSeconds, Consumer<Map<Long, Attack>> consumer) {
+        return repeating(UserSelections.ATTACKS, intervalInSeconds,UserMapper::ofAttacks, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, Attack>> repeatAttacksFull(int intervalInSeconds, Consumer<Map<Long, Attack>> consumer) {
+        return repeating(UserSelections.ATTACKSFULL, intervalInSeconds,UserMapper::ofAttacks, consumer);
+    }
+
+    public RepeatingRequestTask<Bars> repeatBars(int intervalInSeconds, Consumer<Bars> consumer) {
+        return repeating(UserSelections.BARS, intervalInSeconds,UserMapper::ofBars, consumer);
+    }
+
+    public RepeatingRequestTask<Basic> repeatBasic(int intervalInSeconds, Consumer<Basic> consumer) {
+        return repeating(UserSelections.BASIC, intervalInSeconds,UserMapper::ofBasic, consumer);
+    }
+
+    public RepeatingRequestTask<BattleStats> repeatBattleStats(int intervalInSeconds, Consumer<BattleStats> consumer) {
+        return repeating(UserSelections.BATTLESTATS, intervalInSeconds,UserMapper::ofBattleStats, consumer);
+    }
+
+    public RepeatingRequestTask<List<BazaarItem>> repeatBazaar(int intervalInSeconds, Consumer<List<BazaarItem>> consumer) {
+        return repeating(UserSelections.BAZAAR, intervalInSeconds,UserMapper::ofBazaar, consumer);
+    }
+
+    public RepeatingRequestTask<Cooldowns> repeatCooldowns(int intervalInSeconds, Consumer<Cooldowns> consumer) {
+        return repeating(UserSelections.COOLDOWNS, intervalInSeconds,UserMapper::ofCooldowns, consumer);
+    }
+
+    public RepeatingRequestTask<CriminalRecord> repeatCrimes(int intervalInSeconds, Consumer<CriminalRecord> consumer) {
+        return repeating(UserSelections.CRIMES, intervalInSeconds,UserMapper::ofCrimes, consumer);
+    }
+
+    public RepeatingRequestTask<Discord> repeatDiscord(int intervalInSeconds, Consumer<Discord> consumer) {
+        return repeating(UserSelections.DISCORD, intervalInSeconds,UserMapper::ofDiscord, consumer);
+    }
+
+    public RepeatingRequestTask<List<DisplayItem>> repeatDisplay(int intervalInSeconds, Consumer<List<DisplayItem>> consumer) {
+        return repeating(UserSelections.DISPLAY, intervalInSeconds,UserMapper::ofDisplay, consumer);
+    }
+
+    public RepeatingRequestTask<Education> repeatEducation(int intervalInSeconds, Consumer<Education> consumer) {
+        return repeating(UserSelections.EDUCATION, intervalInSeconds,UserMapper::ofEducation, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, Event>> repeatEvents(int intervalInSeconds, Consumer<Map<Long, Event>> consumer) {
+        return repeating(UserSelections.EVENTS, intervalInSeconds,UserMapper::ofEvents, consumer);
+    }
+
+    public RepeatingRequestTask<Gym> repeatGym(int intervalInSeconds, Consumer<Gym> consumer) {
+        return repeating(UserSelections.GYM, intervalInSeconds,UserMapper::ofGym, consumer);
+    }
+
+    public RepeatingRequestTask<Map<String, HOF>> repeatHof(int intervalInSeconds, Consumer<Map<String, HOF>> consumer) {
+        return repeating(UserSelections.HOF, intervalInSeconds,UserMapper::ofHOF, consumer);
+    }
+
+    public RepeatingRequestTask<List<Honor>> repeatHonors(int intervalInSeconds, Consumer<List<Honor>> consumer) {
+        return repeating(UserSelections.HONORS, intervalInSeconds,UserMapper::ofHonors, consumer);
+    }
+
+    public RepeatingRequestTask<Map<String, String>> repeatIcons(int intervalInSeconds, Consumer<Map<String, String>> consumer) {
+        return repeating(UserSelections.ICONS, intervalInSeconds,UserMapper::ofIcons, consumer);
+    }
+
+    public RepeatingRequestTask<List<InventoryItem>> repeatInventory(int intervalInSeconds, Consumer<List<InventoryItem>> consumer) {
+        return repeating(UserSelections.INVENTORY, intervalInSeconds,UserMapper::ofInventory, consumer);
+    }
+
+    public RepeatingRequestTask<JobPoints> repeatJobPoints(int intervalInSeconds, Consumer<JobPoints> consumer) {
+        return repeating(UserSelections.JOBPOINTS, intervalInSeconds,UserMapper::ofJobPoints, consumer);
+    }
+
+    public RepeatingRequestTask<Map<String, Log>> repeatLog(int intervalInSeconds, Consumer<Map<String, Log>> consumer) {
+        return repeating(UserSelections.LOG, intervalInSeconds,UserMapper::ofLog, consumer);
+    }
+
+    public RepeatingRequestTask<Map<String, Message>> repeatMessages(int intervalInSeconds, Consumer<Map<String, Message>> consumer) {
+        return repeating(UserSelections.MESSAGES, intervalInSeconds,UserMapper::ofMessages, consumer);
+    }
+
+    public RepeatingRequestTask<Missions> repeatMissions(int intervalInSeconds, Consumer<Missions> consumer) {
+        return repeating(UserSelections.MISSIONS, intervalInSeconds,UserMapper::ofMissions, consumer);
+    }
+
+    public RepeatingRequestTask<Money> repeatMoney(int intervalInSeconds, Consumer<Money> consumer) {
+        return repeating(UserSelections.MONEY, intervalInSeconds,UserMapper::ofMoney, consumer);
+    }
+
+    public RepeatingRequestTask<Networth> repeatNetWorth(int intervalInSeconds, Consumer<Networth> consumer) {
+        return repeating(UserSelections.NETWORTH, intervalInSeconds,UserMapper::ofNetworth, consumer);
+    }
+
+    public RepeatingRequestTask<Notifications> repeatNotifications(int intervalInSeconds, Consumer<Notifications> consumer) {
+        return repeating(UserSelections.NOTIFICATIONS, intervalInSeconds,UserMapper::ofNotifications, consumer);
+    }
+
+    public RepeatingRequestTask<Perks> repeatPerks(int intervalInSeconds, Consumer<Perks> consumer) {
+        return repeating(UserSelections.PERKS, intervalInSeconds,UserMapper::ofPerks, consumer);
+    }
+
+    public RepeatingRequestTask<PersonalStats> repeatPersonalStats(int intervalInSeconds, Consumer<PersonalStats> consumer) {
+        return repeating(UserSelections.PERSONALSTATS, intervalInSeconds,UserMapper::ofPersonalStats, consumer);
+    }
+
+    public RepeatingRequestTask<Profile> repeatProfile(int intervalInSeconds, Consumer<Profile> consumer) {
+        return repeating(UserSelections.PROFILE, intervalInSeconds,UserMapper::ofProfile, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, Property>> repeatProperties(int intervalInSeconds, Consumer<Map<Long, Property>> consumer) {
+        return repeating(UserSelections.PROPERTIES, intervalInSeconds,UserMapper::ofProperties, consumer);
+    }
+
+    public RepeatingRequestTask<Refills> repeatRefills(int intervalInSeconds, Consumer<Refills> consumer) {
+        return repeating(UserSelections.REFILLS, intervalInSeconds,UserMapper::ofRefills, consumer);
+    }
+
+    public RepeatingRequestTask<List<Report>> repeatReports(int intervalInSeconds, Consumer<List<Report>> consumer) {
+        return repeating(UserSelections.REPORTS, intervalInSeconds,UserMapper::ofReports, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, Revive>> repeatRevives(int intervalInSeconds, Consumer<Map<Long, Revive>> consumer) {
+        return repeating(UserSelections.REVIVES, intervalInSeconds,UserMapper::ofRevives, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, Revive>> repeatRevivesFull(int intervalInSeconds, Consumer<Map<Long, Revive>> consumer) {
+        return repeating(UserSelections.REVIVESFULL, intervalInSeconds,UserMapper::ofRevives, consumer);
+    }
+
+    public RepeatingRequestTask<Skills> repeatSkills(int intervalInSeconds, Consumer<Skills> consumer) {
+        return repeating(UserSelections.SKILLS, intervalInSeconds,UserMapper::ofSkills, consumer);
+    }
+
+    public RepeatingRequestTask<Map<Long, Stock>> repeatStocks(int intervalInSeconds, Consumer<Map<Long, Stock>> consumer) {
+        return repeating(UserSelections.STOCKS, intervalInSeconds,UserMapper::ofStocks, consumer);
+    }
+
+    public RepeatingRequestTask<Travel> repeatTravel(int intervalInSeconds, Consumer<Travel> consumer) {
+        return repeating(UserSelections.TRAVEL, intervalInSeconds,UserMapper::ofTravel, consumer);
+    }
+
+    public RepeatingRequestTask<List<WeaponExperience>> repeatWeaponExp(int intervalInSeconds, Consumer<List<WeaponExperience>> consumer) {
+        return repeating(UserSelections.WEAPONEXP, intervalInSeconds,UserMapper::ofWeaponExp, consumer);
+    }
+
+    public RepeatingRequestTask<WorkStats> repeatWorkStats(int intervalInSeconds, Consumer<WorkStats> consumer) {
+        return repeating(UserSelections.WORKSTATS, intervalInSeconds,UserMapper::ofWorkStats, consumer);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRepeatingRequestBuilder.java
@@ -17,8 +17,8 @@ public class UserRepeatingRequestBuilder extends RequestBuilder<UserSelections> 
     }
 
     @Override
-    public UserRepeatingRequestBuilder throwTornError() {
-        super.throwTornError();
+    public UserRepeatingRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRequestBuilder.java
@@ -2,11 +2,10 @@ package eu.tornplayground.tornapi.requestbuilder;
 
 import eu.tornplayground.tornapi.RequestBuilder;
 import eu.tornplayground.tornapi.TornApi;
-import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.TornErrorException;
 import eu.tornplayground.tornapi.connector.TornHttpException;
 import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
 import eu.tornplayground.tornapi.mappers.UserMapper;
-import eu.tornplayground.tornapi.models.Timestamp;
 import eu.tornplayground.tornapi.models.user.*;
 import eu.tornplayground.tornapi.selections.UserSelections;
 
@@ -20,160 +19,160 @@ public class UserRequestBuilder extends RequestBuilder<UserSelections> {
     }
 
     @Override
-    public UserRequestBuilder throwTornError() {
-        super.throwTornError();
+    public UserRequestBuilder withTornErrorException(boolean throwError) {
+        super.withTornErrorException(throwError);
         return this;
     }
 
-    public List<Ammo> fetchAmmo() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<Ammo> fetchAmmo() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.AMMO, UserMapper::ofAmmo);
     }
 
-    public Map<Long, Attack> fetchAttacks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, Attack> fetchAttacks() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.ATTACKS, UserMapper::ofAttacks);
     }
 
-    public Map<Long, Attack> fetchAttacksFull() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, Attack> fetchAttacksFull() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.ATTACKSFULL, UserMapper::ofAttacks);
     }
 
-    public Bars fetchBars() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Bars fetchBars() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.BARS, UserMapper::ofBars);
     }
 
-    public Basic fetchBasic() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Basic fetchBasic() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.BASIC, UserMapper::ofBasic);
     }
 
-    public BattleStats fetchBattleStats() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public BattleStats fetchBattleStats() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.BATTLESTATS, UserMapper::ofBattleStats);
     }
 
-    public List<BazaarItem> fetchBazaar() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<BazaarItem> fetchBazaar() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.BAZAAR, UserMapper::ofBazaar);
     }
 
-    public Cooldowns fetchCooldowns() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Cooldowns fetchCooldowns() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.COOLDOWNS, UserMapper::ofCooldowns);
     }
 
-    public CriminalRecord fetchCrimes() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public CriminalRecord fetchCrimes() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.CRIMES, UserMapper::ofCrimes);
     }
 
-    public Discord fetchDiscord() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Discord fetchDiscord() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.DISCORD, UserMapper::ofDiscord);
     }
 
-    public List<DisplayItem> fetchDisplay() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<DisplayItem> fetchDisplay() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.DISPLAY, UserMapper::ofDisplay);
     }
 
-    public Education fetchEducation() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Education fetchEducation() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.EDUCATION, UserMapper::ofEducation);
     }
 
-    public Map<Long, Event> fetchEvents() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, Event> fetchEvents() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.EVENTS, UserMapper::ofEvents);
     }
 
-    public Gym fetchGym() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Gym fetchGym() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.GYM, UserMapper::ofGym);
     }
 
-    public Map<String, HOF> fetchHof() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<String, HOF> fetchHof() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.HOF, UserMapper::ofHOF);
     }
 
-    public List<Honor> fetchHonors() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<Honor> fetchHonors() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.HONORS, UserMapper::ofHonors);
     }
 
-    public Map<String, String> fetchIcons() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<String, String> fetchIcons() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.ICONS, UserMapper::ofIcons);
     }
 
-    public List<InventoryItem> fetchInventory() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<InventoryItem> fetchInventory() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.INVENTORY, UserMapper::ofInventory);
     }
 
-    public JobPoints fetchJobPoints() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public JobPoints fetchJobPoints() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.JOBPOINTS, UserMapper::ofJobPoints);
     }
 
-    public Map<String, Log> fetchLog() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<String, Log> fetchLog() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.LOG, UserMapper::ofLog);
     }
 
-    public Map<String, Message> fetchMessages() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<String, Message> fetchMessages() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.MESSAGES, UserMapper::ofMessages);
     }
 
-    public Missions fetchMissions() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Missions fetchMissions() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.MISSIONS, UserMapper::ofMissions);
     }
 
-    public Money fetchMoney() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Money fetchMoney() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.MONEY, UserMapper::ofMoney);
     }
 
-    public Networth fetchNetWorth() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Networth fetchNetWorth() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.NETWORTH, UserMapper::ofNetworth);
     }
 
-    public Notifications fetchNotifications() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Notifications fetchNotifications() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.NOTIFICATIONS, UserMapper::ofNotifications);
     }
 
-    public Perks fetchPerks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Perks fetchPerks() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.PERKS, UserMapper::ofPerks);
     }
 
-    public PersonalStats fetchPersonalStats() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public PersonalStats fetchPersonalStats() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.PERSONALSTATS, UserMapper::ofPersonalStats);
     }
 
-    public Profile fetchProfile() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Profile fetchProfile() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.PROFILE, UserMapper::ofProfile);
     }
 
-    public Map<Long, Property> fetchProperties() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, Property> fetchProperties() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.PROPERTIES, UserMapper::ofProperties);
     }
 
-    public Refills fetchRefills() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Refills fetchRefills() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.REFILLS, UserMapper::ofRefills);
     }
 
-    public List<Report> fetchReports() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<Report> fetchReports() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.REPORTS, UserMapper::ofReports);
     }
 
-    public Map<Long, Revive> fetchRevives() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, Revive> fetchRevives() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.REVIVES, UserMapper::ofRevives);
     }
 
-    public Map<Long, Revive> fetchRevivesFull() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, Revive> fetchRevivesFull() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.REVIVESFULL, UserMapper::ofRevives);
     }
 
-    public Skills fetchSkills() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Skills fetchSkills() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.SKILLS, UserMapper::ofSkills);
     }
 
-    public Map<Long, Stock> fetchStocks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Map<Long, Stock> fetchStocks() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.STOCKS, UserMapper::ofStocks);
     }
 
-    public Travel fetchTravel() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public Travel fetchTravel() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.TRAVEL, UserMapper::ofTravel);
     }
 
-    public List<WeaponExperience> fetchWeaponExp() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public List<WeaponExperience> fetchWeaponExp() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.WEAPONEXP, UserMapper::ofWeaponExp);
     }
 
-    public WorkStats fetchWorkStats() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+    public WorkStats fetchWorkStats() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(UserSelections.WORKSTATS, UserMapper::ofWorkStats);
     }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRequestBuilder.java
@@ -19,6 +19,12 @@ public class UserRequestBuilder extends RequestBuilder<UserSelections> {
         super(tornApi, "user");
     }
 
+    @Override
+    public UserRequestBuilder throwTornError() {
+        super.throwTornError();
+        return this;
+    }
+
     public List<Ammo> fetchAmmo() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
         return fetch(UserSelections.AMMO, UserMapper::ofAmmo);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRequestBuilder.java
@@ -1,0 +1,173 @@
+package eu.tornplayground.tornapi.requestbuilder;
+
+import eu.tornplayground.tornapi.RequestBuilder;
+import eu.tornplayground.tornapi.TornApi;
+import eu.tornplayground.tornapi.TornApiErrorException;
+import eu.tornplayground.tornapi.connector.TornHttpException;
+import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
+import eu.tornplayground.tornapi.mappers.UserMapper;
+import eu.tornplayground.tornapi.models.Timestamp;
+import eu.tornplayground.tornapi.models.user.*;
+import eu.tornplayground.tornapi.selections.UserSelections;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class UserRequestBuilder extends RequestBuilder<UserSelections> {
+    public UserRequestBuilder(TornApi tornApi) {
+        super(tornApi, "user");
+    }
+
+    public List<Ammo> fetchAmmo() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.AMMO, UserMapper::ofAmmo);
+    }
+
+    public Map<Long, Attack> fetchAttacks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.ATTACKS, UserMapper::ofAttacks);
+    }
+
+    public Map<Long, Attack> fetchAttacksFull() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.ATTACKSFULL, UserMapper::ofAttacks);
+    }
+
+    public Bars fetchBars() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.BARS, UserMapper::ofBars);
+    }
+
+    public Basic fetchBasic() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.BASIC, UserMapper::ofBasic);
+    }
+
+    public BattleStats fetchBattleStats() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.BATTLESTATS, UserMapper::ofBattleStats);
+    }
+
+    public List<BazaarItem> fetchBazaar() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.BAZAAR, UserMapper::ofBazaar);
+    }
+
+    public Cooldowns fetchCooldowns() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.COOLDOWNS, UserMapper::ofCooldowns);
+    }
+
+    public CriminalRecord fetchCrimes() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.CRIMES, UserMapper::ofCrimes);
+    }
+
+    public Discord fetchDiscord() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.DISCORD, UserMapper::ofDiscord);
+    }
+
+    public List<DisplayItem> fetchDisplay() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.DISPLAY, UserMapper::ofDisplay);
+    }
+
+    public Education fetchEducation() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.EDUCATION, UserMapper::ofEducation);
+    }
+
+    public Map<Long, Event> fetchEvents() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.EVENTS, UserMapper::ofEvents);
+    }
+
+    public Gym fetchGym() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.GYM, UserMapper::ofGym);
+    }
+
+    public Map<String, HOF> fetchHof() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.HOF, UserMapper::ofHOF);
+    }
+
+    public List<Honor> fetchHonors() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.HONORS, UserMapper::ofHonors);
+    }
+
+    public Map<String, String> fetchIcons() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.ICONS, UserMapper::ofIcons);
+    }
+
+    public List<InventoryItem> fetchInventory() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.INVENTORY, UserMapper::ofInventory);
+    }
+
+    public JobPoints fetchJobPoints() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.JOBPOINTS, UserMapper::ofJobPoints);
+    }
+
+    public Map<String, Log> fetchLog() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.LOG, UserMapper::ofLog);
+    }
+
+    public Map<String, Message> fetchMessages() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.MESSAGES, UserMapper::ofMessages);
+    }
+
+    public Missions fetchMissions() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.MISSIONS, UserMapper::ofMissions);
+    }
+
+    public Money fetchMoney() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.MONEY, UserMapper::ofMoney);
+    }
+
+    public Networth fetchNetWorth() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.NETWORTH, UserMapper::ofNetworth);
+    }
+
+    public Notifications fetchNotifications() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.NOTIFICATIONS, UserMapper::ofNotifications);
+    }
+
+    public Perks fetchPerks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.PERKS, UserMapper::ofPerks);
+    }
+
+    public PersonalStats fetchPersonalStats() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.PERSONALSTATS, UserMapper::ofPersonalStats);
+    }
+
+    public Profile fetchProfile() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.PROFILE, UserMapper::ofProfile);
+    }
+
+    public Map<Long, Property> fetchProperties() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.PROPERTIES, UserMapper::ofProperties);
+    }
+
+    public Refills fetchRefills() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.REFILLS, UserMapper::ofRefills);
+    }
+
+    public List<Report> fetchReports() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.REPORTS, UserMapper::ofReports);
+    }
+
+    public Map<Long, Revive> fetchRevives() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.REVIVES, UserMapper::ofRevives);
+    }
+
+    public Map<Long, Revive> fetchRevivesFull() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.REVIVESFULL, UserMapper::ofRevives);
+    }
+
+    public Skills fetchSkills() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.SKILLS, UserMapper::ofSkills);
+    }
+
+    public Map<Long, Stock> fetchStocks() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.STOCKS, UserMapper::ofStocks);
+    }
+
+    public Travel fetchTravel() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.TRAVEL, UserMapper::ofTravel);
+    }
+
+    public List<WeaponExperience> fetchWeaponExp() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.WEAPONEXP, UserMapper::ofWeaponExp);
+    }
+
+    public WorkStats fetchWorkStats() throws IOException, TornHttpException, InterruptedException, TornApiErrorException, RequestLimitReachedException {
+        return fetch(UserSelections.WORKSTATS, UserMapper::ofWorkStats);
+    }
+}

--- a/src/main/java/eu/tornplayground/tornapi/selections/CompanySelections.java
+++ b/src/main/java/eu/tornplayground/tornapi/selections/CompanySelections.java
@@ -1,16 +1,13 @@
 package eu.tornplayground.tornapi.selections;
 
 public enum CompanySelections implements Selection {
-
     COMPANIES,
-
     APPLICATIONS,
     DETAILED,
     EMPLOYEES,
     NEWS,
     PROFILE,
     STOCK,
-
     TIMESTAMP;
 
     @Override

--- a/src/test/java/eu/tornplayground/tornapi/TornApiTest.java
+++ b/src/test/java/eu/tornplayground/tornapi/TornApiTest.java
@@ -3,9 +3,12 @@ package eu.tornplayground.tornapi;
 import eu.tornplayground.tornapi.connector.ApiConnector;
 import eu.tornplayground.tornapi.connector.TornHttpException;
 import eu.tornplayground.tornapi.keyprovider.KeyProvider;
+import eu.tornplayground.tornapi.keyprovider.SingleKeyProvider;
 import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
+import eu.tornplayground.tornapi.limiter.RequestLimiter;
 import eu.tornplayground.tornapi.selections.*;
 import org.assertj.core.api.AbstractUriAssert;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +33,7 @@ class TornApiTest {
 
     private TornApi api;
 
-    private URI captureUri() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    private URI captureUri() throws IOException, InterruptedException, TornHttpException {
         ArgumentCaptor<String> argumentCaptorUrl = ArgumentCaptor.forClass(String.class);
 
         verify(connector).connect(argumentCaptorUrl.capture());
@@ -67,7 +70,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchCurrentUser() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchCurrentUser() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forUser()
                 .withSelections(UserSelections.PROFILE, UserSelections.PERSONALSTATS)
@@ -87,7 +90,7 @@ class TornApiTest {
 
 
     @Test
-    void fetchCurrentUserWithKeyProvider() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchCurrentUserWithKeyProvider() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         KeyProvider keyProvider = Mockito.mock(KeyProvider.class);
 
         TornApi api = new TornApi(connector, keyProvider);
@@ -111,7 +114,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchCurrentUserWithParameters() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchCurrentUserWithParameters() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forUser()
                 .withSelections(UserSelections.PROFILE, UserSelections.PERSONALSTATS)
@@ -134,7 +137,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchUser() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchUser() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forUser()
                 .id(1)
@@ -154,7 +157,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchUserWithStringId() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchUserWithStringId() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forUser()
                 .id("discord-id")
@@ -173,7 +176,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchUserWithParameters() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchUserWithParameters() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forUser()
                 .id(1)
@@ -197,7 +200,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchUserWithParametersAndStringId() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchUserWithParametersAndStringId() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forUser()
                 .id("discord-id")
@@ -220,7 +223,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchCurrentProperty() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchCurrentProperty() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forProperties()
                 .withSelections(PropertiesSelections.PROPERTY)
@@ -238,7 +241,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchCurrentFaction() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchCurrentFaction() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forFaction()
                 .withSelections(FactionSelections.BASIC, FactionSelections.TERRITORY)
@@ -256,7 +259,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchCurrentCompany() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchCurrentCompany() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forCompany()
                 .withSelections(CompanySelections.PROFILE, CompanySelections.EMPLOYEES)
@@ -274,7 +277,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchMultipleItems() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchMultipleItems() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forMarket()
                 .id("1,2,3")
@@ -293,7 +296,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchAllEducations() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchAllEducations() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forTorn()
                 .withSelections(TornSelections.EDUCATION)
@@ -311,7 +314,7 @@ class TornApiTest {
     }
 
     @Test
-    void fetchKeyInformation() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void fetchKeyInformation() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forKey()
                 .withSelections(KeySelections.INFO)
@@ -329,7 +332,7 @@ class TornApiTest {
     }
 
     @Test
-    void givenNoDefaultComment_whenFetchWithoutComment_thenNoComment() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void givenNoDefaultComment_whenFetchWithoutComment_thenNoComment() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forUser()
                 .withKey("test-key")
@@ -342,7 +345,7 @@ class TornApiTest {
     }
 
     @Test
-    void givenDefaultComment_whenFetchWithoutComment_thenDefaultComment() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void givenDefaultComment_whenFetchWithoutComment_thenDefaultComment() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api.withComment("testing-default");
         api
                 .forUser()
@@ -356,7 +359,7 @@ class TornApiTest {
     }
 
     @Test
-    void givenDefaultComment_whenFetchWithComment_thenComment() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void givenDefaultComment_whenFetchWithComment_thenComment() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api.withComment("testing-default");
         api
                 .forUser()
@@ -371,7 +374,7 @@ class TornApiTest {
     }
 
     @Test
-    void givenNoDefaultComment_whenFetchWithComment_thenComment() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+    void givenNoDefaultComment_whenFetchWithComment_thenComment() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
         api
                 .forUser()
                 .withKey("test-key")
@@ -384,4 +387,53 @@ class TornApiTest {
                 .hasParameter("comment", "testing");
     }
 
+    @Test
+    void automaticKeyConsumptionTest() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
+
+        TornApi automaticKeyConsumption = new TornApi(connector, new SingleKeyProvider("key1"))
+                .withAutomaticKeyConsumption(true);
+
+        automaticKeyConsumption.forUser().fetch();
+        assertUri(captureUri(), "key1");
+    }
+
+    @Test
+    void overwriteAutomaticKeyConsumptionTest() throws IOException, InterruptedException, TornHttpException, RequestLimitReachedException, TornErrorException {
+
+        TornApi automaticKeyConsumption = new TornApi(connector, new SingleKeyProvider("key1"))
+                .withAutomaticKeyConsumption(true);
+
+        automaticKeyConsumption.forUser().withKey("key2").fetch();
+        assertUri(captureUri(), "key2");
+    }
+
+    @Test
+    void limitReachedExceptionTest() throws TornHttpException, IOException, RequestLimitReachedException, TornErrorException {
+        TornApi automaticKeyConsumption = new TornApi(connector, new SingleKeyProvider("key1"))
+                .withRequestLimiter(new RequestLimiter((short) 1, 60, true))
+                .withAutomaticKeyConsumption(true);
+
+        SoftAssertions softly = new SoftAssertions();
+
+        automaticKeyConsumption.forUser().fetch();
+        softly.assertThatCode(() -> automaticKeyConsumption.forUser().fetch()).isInstanceOf(RequestLimitReachedException.class);
+
+        softly.assertAll();
+    }
+
+    @Test
+    void limitReachedSleepingTest() throws TornHttpException, IOException, RequestLimitReachedException, TornErrorException {
+        TornApi automaticKeyConsumption = new TornApi(connector, new SingleKeyProvider("key1"))
+                .withRequestLimiter(new RequestLimiter((short) 1, 2))
+                .withAutomaticKeyConsumption(true);
+
+        SoftAssertions softly = new SoftAssertions();
+
+        long start = System.currentTimeMillis();
+        automaticKeyConsumption.forUser().fetch();
+        automaticKeyConsumption.forUser().fetch();
+        softly.assertThat(System.currentTimeMillis() - start).isGreaterThan(2000).isLessThan(2100);
+
+        softly.assertAll();
+    }
 }

--- a/src/test/java/eu/tornplayground/tornapi/TornApiTest.java
+++ b/src/test/java/eu/tornplayground/tornapi/TornApiTest.java
@@ -3,6 +3,7 @@ package eu.tornplayground.tornapi;
 import eu.tornplayground.tornapi.connector.ApiConnector;
 import eu.tornplayground.tornapi.connector.TornHttpException;
 import eu.tornplayground.tornapi.keyprovider.KeyProvider;
+import eu.tornplayground.tornapi.limiter.RequestLimitReachedException;
 import eu.tornplayground.tornapi.selections.*;
 import org.assertj.core.api.AbstractUriAssert;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +30,7 @@ class TornApiTest {
 
     private TornApi api;
 
-    private URI captureUri() throws IOException, InterruptedException, TornHttpException {
+    private URI captureUri() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         ArgumentCaptor<String> argumentCaptorUrl = ArgumentCaptor.forClass(String.class);
 
         verify(connector).connect(argumentCaptorUrl.capture());
@@ -62,16 +63,16 @@ class TornApiTest {
 
     @BeforeEach
     void setUp() {
-        this.api = new TornApi(connector);
+        this.api = new TornApi(connector, null);
     }
 
     @Test
-    void fetchCurrentUser() throws IOException, InterruptedException, TornHttpException {
+    void fetchCurrentUser() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
-                .forUsers()
+                .forUser()
                 .withSelections(UserSelections.PROFILE, UserSelections.PERSONALSTATS)
                 .withSelections("anything")
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -86,14 +87,14 @@ class TornApiTest {
 
 
     @Test
-    void fetchCurrentUserWithKeyProvider() throws IOException, InterruptedException, TornHttpException {
+    void fetchCurrentUserWithKeyProvider() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         KeyProvider keyProvider = Mockito.mock(KeyProvider.class);
 
         TornApi api = new TornApi(connector, keyProvider);
 
         when(keyProvider.next()).thenReturn("key-provider");
         api
-                .forUsers()
+                .forUser()
                 .withSelections(UserSelections.PROFILE, UserSelections.PERSONALSTATS)
                 .withSelections("anything")
                 .consumeKey()
@@ -110,14 +111,14 @@ class TornApiTest {
     }
 
     @Test
-    void fetchCurrentUserWithParameters() throws IOException, InterruptedException, TornHttpException {
+    void fetchCurrentUserWithParameters() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
-                .forUsers()
+                .forUser()
                 .withSelections(UserSelections.PROFILE, UserSelections.PERSONALSTATS)
                 .withSelections("anything")
                 .withParameter("from", 1577836800)
                 .withParameter("to", 1609459199)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -133,13 +134,13 @@ class TornApiTest {
     }
 
     @Test
-    void fetchUser() throws IOException, InterruptedException, TornHttpException {
+    void fetchUser() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
-                .forUsers()
+                .forUser()
                 .id(1)
                 .withSelections(UserSelections.PROFILE, UserSelections.PERSONALSTATS)
                 .withSelections("anything")
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -153,12 +154,12 @@ class TornApiTest {
     }
 
     @Test
-    void fetchUserWithStringId() throws IOException, InterruptedException, TornHttpException {
+    void fetchUserWithStringId() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
-                .forUsers()
+                .forUser()
                 .id("discord-id")
                 .withSelections(UserSelections.DISCORD)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -172,15 +173,15 @@ class TornApiTest {
     }
 
     @Test
-    void fetchUserWithParameters() throws IOException, InterruptedException, TornHttpException {
+    void fetchUserWithParameters() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
-                .forUsers()
+                .forUser()
                 .id(1)
                 .withSelections(UserSelections.PROFILE, UserSelections.PERSONALSTATS)
                 .withSelections("anything")
                 .withParameter("from", 1577836800)
                 .withParameter("to", 1609459199)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -196,14 +197,14 @@ class TornApiTest {
     }
 
     @Test
-    void fetchUserWithParametersAndStringId() throws IOException, InterruptedException, TornHttpException {
+    void fetchUserWithParametersAndStringId() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
-                .forUsers()
+                .forUser()
                 .id("discord-id")
                 .withSelections(UserSelections.DISCORD)
                 .withParameter("from", 1577836800)
                 .withParameter("to", 1609459199)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -219,11 +220,11 @@ class TornApiTest {
     }
 
     @Test
-    void fetchCurrentProperty() throws IOException, InterruptedException, TornHttpException {
+    void fetchCurrentProperty() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
                 .forProperties()
                 .withSelections(PropertiesSelections.PROPERTY)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -237,11 +238,11 @@ class TornApiTest {
     }
 
     @Test
-    void fetchCurrentFaction() throws IOException, InterruptedException, TornHttpException {
+    void fetchCurrentFaction() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
                 .forFaction()
                 .withSelections(FactionSelections.BASIC, FactionSelections.TERRITORY)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -255,11 +256,11 @@ class TornApiTest {
     }
 
     @Test
-    void fetchCurrentCompany() throws IOException, InterruptedException, TornHttpException {
+    void fetchCurrentCompany() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
                 .forCompany()
                 .withSelections(CompanySelections.PROFILE, CompanySelections.EMPLOYEES)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -273,12 +274,12 @@ class TornApiTest {
     }
 
     @Test
-    void fetchMultipleItems() throws IOException, InterruptedException, TornHttpException {
+    void fetchMultipleItems() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
                 .forMarket()
                 .id("1,2,3")
                 .withSelections(ItemMarketSelections.BAZAAR, ItemMarketSelections.ITEMMARKET)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -292,11 +293,11 @@ class TornApiTest {
     }
 
     @Test
-    void fetchAllEducations() throws IOException, InterruptedException, TornHttpException {
+    void fetchAllEducations() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
                 .forTorn()
                 .withSelections(TornSelections.EDUCATION)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -310,11 +311,11 @@ class TornApiTest {
     }
 
     @Test
-    void fetchKeyInformation() throws IOException, InterruptedException, TornHttpException {
+    void fetchKeyInformation() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
                 .forKey()
                 .withSelections(KeySelections.INFO)
-                .key("test-key")
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -328,10 +329,10 @@ class TornApiTest {
     }
 
     @Test
-    void givenNoDefaultComment_whenFetchWithoutComment_thenNoComment() throws IOException, InterruptedException, TornHttpException {
+    void givenNoDefaultComment_whenFetchWithoutComment_thenNoComment() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
-                .forUsers()
-                .key("test-key")
+                .forUser()
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -341,11 +342,11 @@ class TornApiTest {
     }
 
     @Test
-    void givenDefaultComment_whenFetchWithoutComment_thenDefaultComment() throws IOException, InterruptedException, TornHttpException {
-        api.setDefaultComment("testing-default");
+    void givenDefaultComment_whenFetchWithoutComment_thenDefaultComment() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+        api.withComment("testing-default");
         api
-                .forUsers()
-                .key("test-key")
+                .forUser()
+                .withKey("test-key")
                 .fetch();
 
         URI uri = captureUri();
@@ -355,11 +356,11 @@ class TornApiTest {
     }
 
     @Test
-    void givenDefaultComment_whenFetchWithComment_thenComment() throws IOException, InterruptedException, TornHttpException {
-        api.setDefaultComment("testing-default");
+    void givenDefaultComment_whenFetchWithComment_thenComment() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
+        api.withComment("testing-default");
         api
-                .forUsers()
-                .key("test-key")
+                .forUser()
+                .withKey("test-key")
                 .withComment("testing")
                 .fetch();
 
@@ -370,10 +371,10 @@ class TornApiTest {
     }
 
     @Test
-    void givenNoDefaultComment_whenFetchWithComment_thenComment() throws IOException, InterruptedException, TornHttpException {
+    void givenNoDefaultComment_whenFetchWithComment_thenComment() throws IOException, InterruptedException, TornHttpException, TornApiErrorException, RequestLimitReachedException {
         api
-                .forUsers()
-                .key("test-key")
+                .forUser()
+                .withKey("test-key")
                 .withComment("testing")
                 .fetch();
 


### PR DESCRIPTION
The main goal here was to a) clean up the TornApi class and b) add some utility classes to handle single selection requests as well as async and repeating tasks.

I personally use repeating tasks quite often because i want to check the another factions members to send notifications to discord.. or want to check the item market. 

Actually at least half of my requests are running in scheduled tasks. So maybe this is more of a feature for me and me alone, idk. 