### PR TITLE
fix: fix chaining issue & major issue with the request limiters thread safety

### DIFF
--- a/src/main/java/eu/tornplayground/tornapi/RequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/RequestBuilder.java
@@ -159,13 +159,7 @@ public abstract class RequestBuilder<T extends Selection> {
         }
 
         if (tornApi.getRequestLimiter() != null) {
-            try {
-                tornApi.getRequestLimiter().handleRequest(getKey());
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                // at this point there is an issue with the wrapper itself and the user should not have to "handle" that, because he can't really do anything about it
-                throw new RuntimeException("Something went horribly wrong, while waiting for the limiter", e);
-            }
+            tornApi.getRequestLimiter().handleRequest(getKey());
         }
 
         final URI uri = buildUri();

--- a/src/main/java/eu/tornplayground/tornapi/keyprovider/MultiKeyProvider.java
+++ b/src/main/java/eu/tornplayground/tornapi/keyprovider/MultiKeyProvider.java
@@ -1,28 +1,19 @@
 package eu.tornplayground.tornapi.keyprovider;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class MultiKeyProvider implements KeyProvider {
 
-    private final LinkedList<String> keys;
-    private int currentKeyIndex = 0;
+    private final String[] keys;
+    private final AtomicInteger currentKeyIndex = new AtomicInteger(0);
 
     public MultiKeyProvider(String... keys) {
-        this.keys = new LinkedList<>(List.of(keys));
+        this.keys = keys;
     }
 
     @Override
-    public synchronized String next() {
-        if (currentKeyIndex >= keys.size()) {
-            currentKeyIndex = 0;
-        }
-
-        final String nextKey = keys.get(currentKeyIndex++);
-
-        notifyAll();
-
-        return nextKey;
+    public String next() {
+        return keys[currentKeyIndex.getAndUpdate(i -> (i + 1) % keys.length)];
     }
 
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyAsyncRequestBuilder.java
@@ -16,4 +16,33 @@ public class CompanyAsyncRequestBuilder extends RequestBuilder<CompanySelections
         return this;
     }
 
+    @Override
+    public CompanyAsyncRequestBuilder id(long id) {
+        return (CompanyAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public CompanyAsyncRequestBuilder id(String id) {
+        return (CompanyAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public CompanyAsyncRequestBuilder withComment(String comment) {
+        return (CompanyAsyncRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public CompanyAsyncRequestBuilder withParameter(String key, Object value) {
+        return (CompanyAsyncRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public CompanyAsyncRequestBuilder withSelections(String... selections) {
+        return (CompanyAsyncRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public CompanyAsyncRequestBuilder withKey(String key) {
+        return (CompanyAsyncRequestBuilder) super.withKey(key);
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRepeatingRequestBuilder.java
@@ -16,4 +16,33 @@ public class CompanyRepeatingRequestBuilder extends RequestBuilder<CompanySelect
         return this;
     }
 
+    @Override
+    public CompanyRepeatingRequestBuilder id(long id) {
+        return (CompanyRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public CompanyRepeatingRequestBuilder id(String id) {
+        return (CompanyRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public CompanyRepeatingRequestBuilder withComment(String comment) {
+        return (CompanyRepeatingRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public CompanyRepeatingRequestBuilder withParameter(String key, Object value) {
+        return (CompanyRepeatingRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public CompanyRepeatingRequestBuilder withSelections(String... selections) {
+        return (CompanyRepeatingRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public CompanyRepeatingRequestBuilder withKey(String key) {
+        return (CompanyRepeatingRequestBuilder) super.withKey(key);
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/CompanyRequestBuilder.java
@@ -16,4 +16,34 @@ public class CompanyRequestBuilder extends RequestBuilder<CompanySelections> {
         return this;
     }
 
+
+    @Override
+    public CompanyRequestBuilder id(long id) {
+        return (CompanyRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public CompanyRequestBuilder id(String id) {
+        return (CompanyRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public CompanyRequestBuilder withComment(String comment) {
+        return (CompanyRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public CompanyRequestBuilder withParameter(String key, Object value) {
+        return (CompanyRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public CompanyRequestBuilder withSelections(String... selections) {
+        return (CompanyRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public CompanyRequestBuilder withKey(String key) {
+        return (CompanyRequestBuilder) super.withKey(key);
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionAsyncRequestBuilder.java
@@ -21,6 +21,36 @@ public class FactionAsyncRequestBuilder extends RequestBuilder<FactionSelections
         return this;
     }
 
+    @Override
+    public FactionAsyncRequestBuilder id(long id) {
+        return (FactionAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public FactionAsyncRequestBuilder id(String id) {
+        return (FactionAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public FactionAsyncRequestBuilder withComment(String comment) {
+        return (FactionAsyncRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public FactionAsyncRequestBuilder withParameter(String key, Object value) {
+        return (FactionAsyncRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public FactionAsyncRequestBuilder withSelections(String... selections) {
+        return (FactionAsyncRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public FactionAsyncRequestBuilder withKey(String key) {
+        return (FactionAsyncRequestBuilder) super.withKey(key);
+    }
+
     public CompletableFuture<FactionBasic> fetchBasic() {
         return fetchAsync(FactionSelections.BASIC, FactionMapper::ofBasic);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRepeatingRequestBuilder.java
@@ -22,6 +22,36 @@ public class FactionRepeatingRequestBuilder extends RequestBuilder<FactionSelect
         return this;
     }
 
+    @Override
+    public FactionRepeatingRequestBuilder id(long id) {
+        return (FactionRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public FactionRepeatingRequestBuilder id(String id) {
+        return (FactionRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public FactionRepeatingRequestBuilder withComment(String comment) {
+        return (FactionRepeatingRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public FactionRepeatingRequestBuilder withParameter(String key, Object value) {
+        return (FactionRepeatingRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public FactionRepeatingRequestBuilder withSelections(String... selections) {
+        return (FactionRepeatingRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public FactionRepeatingRequestBuilder withKey(String key) {
+        return (FactionRepeatingRequestBuilder) super.withKey(key);
+    }
+
     public RepeatingRequestTask<FactionBasic> repeatBasic(int intervalInSeconds, Consumer<FactionBasic> consumer) {
         return repeating(FactionSelections.BASIC, intervalInSeconds, FactionMapper::ofBasic, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/FactionRequestBuilder.java
@@ -24,6 +24,36 @@ public class FactionRequestBuilder extends RequestBuilder<FactionSelections> {
         return this;
     }
 
+    @Override
+    public FactionRequestBuilder id(long id) {
+        return (FactionRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public FactionRequestBuilder id(String id) {
+        return (FactionRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public FactionRequestBuilder withComment(String comment) {
+        return (FactionRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public FactionRequestBuilder withParameter(String key, Object value) {
+        return (FactionRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public FactionRequestBuilder withSelections(String... selections) {
+        return (FactionRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public FactionRequestBuilder withKey(String key) {
+        return (FactionRequestBuilder) super.withKey(key);
+    }
+
     public FactionBasic fetchBasic() throws IOException, TornHttpException, TornErrorException, RequestLimitReachedException {
         return fetch(FactionSelections.BASIC, FactionMapper::ofBasic);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyAsyncRequestBuilder.java
@@ -20,6 +20,36 @@ public class KeyAsyncRequestBuilder extends RequestBuilder<KeySelections> {
         return this;
     }
 
+    @Override
+    public KeyAsyncRequestBuilder id(long id) {
+        return (KeyAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public KeyAsyncRequestBuilder id(String id) {
+        return (KeyAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public KeyAsyncRequestBuilder withComment(String comment) {
+        return (KeyAsyncRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public KeyAsyncRequestBuilder withParameter(String key, Object value) {
+        return (KeyAsyncRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public KeyAsyncRequestBuilder withSelections(String... selections) {
+        return (KeyAsyncRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public KeyAsyncRequestBuilder withKey(String key) {
+        return (KeyAsyncRequestBuilder) super.withKey(key);
+    }
+
     public CompletableFuture<KeyInfo> fetchInfo() {
         return fetchAsync(KeySelections.INFO, KeyMapper::ofInfo);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRepeatingRequestBuilder.java
@@ -21,6 +21,36 @@ public class KeyRepeatingRequestBuilder extends RequestBuilder<KeySelections> {
         return this;
     }
 
+    @Override
+    public KeyRepeatingRequestBuilder id(long id) {
+        return (KeyRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public KeyRepeatingRequestBuilder id(String id) {
+        return (KeyRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public KeyRepeatingRequestBuilder withComment(String comment) {
+        return (KeyRepeatingRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public KeyRepeatingRequestBuilder withParameter(String key, Object value) {
+        return (KeyRepeatingRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public KeyRepeatingRequestBuilder withSelections(String... selections) {
+        return (KeyRepeatingRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public KeyRepeatingRequestBuilder withKey(String key) {
+        return (KeyRepeatingRequestBuilder) super.withKey(key);
+    }
+
     public RepeatingRequestTask<KeyInfo> repeatInfo(int intervalInSeconds, Consumer<KeyInfo> consumer) {
         return repeating(KeySelections.INFO, intervalInSeconds, KeyMapper::ofInfo, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/KeyRequestBuilder.java
@@ -23,6 +23,36 @@ public class KeyRequestBuilder extends RequestBuilder<KeySelections> {
         return this;
     }
 
+    @Override
+    public KeyRequestBuilder id(long id) {
+        return (KeyRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public KeyRequestBuilder id(String id) {
+        return (KeyRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public KeyRequestBuilder withComment(String comment) {
+        return (KeyRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public KeyRequestBuilder withParameter(String key, Object value) {
+        return (KeyRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public KeyRequestBuilder withSelections(String... selections) {
+        return (KeyRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public KeyRequestBuilder withKey(String key) {
+        return (KeyRequestBuilder) super.withKey(key);
+    }
+
     public KeyInfo fetchInfo() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(KeySelections.INFO, KeyMapper::ofInfo);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketAsyncRequestBuilder.java
@@ -23,6 +23,36 @@ public class MarketAsyncRequestBuilder extends RequestBuilder<ItemMarketSelectio
         return this;
     }
 
+    @Override
+    public MarketAsyncRequestBuilder id(long id) {
+        return (MarketAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public MarketAsyncRequestBuilder id(String id) {
+        return (MarketAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public MarketAsyncRequestBuilder withComment(String comment) {
+        return (MarketAsyncRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public MarketAsyncRequestBuilder withParameter(String key, Object value) {
+        return (MarketAsyncRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public MarketAsyncRequestBuilder withSelections(String... selections) {
+        return (MarketAsyncRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public MarketAsyncRequestBuilder withKey(String key) {
+        return (MarketAsyncRequestBuilder) super.withKey(key);
+    }
+
     public CompletableFuture<List<MarketItem>> fetchBazaar() {
         return fetchAsync(ItemMarketSelections.BAZAAR, MarketMapper::ofBazaar);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRepeatingRequestBuilder.java
@@ -24,6 +24,36 @@ public class MarketRepeatingRequestBuilder extends RequestBuilder<ItemMarketSele
         return this;
     }
 
+    @Override
+    public MarketRepeatingRequestBuilder id(long id) {
+        return (MarketRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public MarketRepeatingRequestBuilder id(String id) {
+        return (MarketRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public MarketRepeatingRequestBuilder withComment(String comment) {
+        return (MarketRepeatingRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public MarketRepeatingRequestBuilder withParameter(String key, Object value) {
+        return (MarketRepeatingRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public MarketRepeatingRequestBuilder withSelections(String... selections) {
+        return (MarketRepeatingRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public MarketRepeatingRequestBuilder withKey(String key) {
+        return (MarketRepeatingRequestBuilder) super.withKey(key);
+    }
+
     public RepeatingRequestTask<List<MarketItem>> repeatBazaar(int intervalInSeconds, Consumer<List<MarketItem>> consumer) {
         return repeating(ItemMarketSelections.BAZAAR, intervalInSeconds, MarketMapper::ofBazaar, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/MarketRequestBuilder.java
@@ -26,6 +26,36 @@ public class MarketRequestBuilder extends RequestBuilder<ItemMarketSelections> {
         return this;
     }
 
+    @Override
+    public MarketRequestBuilder id(long id) {
+        return (MarketRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public MarketRequestBuilder id(String id) {
+        return (MarketRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public MarketRequestBuilder withComment(String comment) {
+        return (MarketRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public MarketRequestBuilder withParameter(String key, Object value) {
+        return (MarketRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public MarketRequestBuilder withSelections(String... selections) {
+        return (MarketRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public MarketRequestBuilder withKey(String key) {
+        return (MarketRequestBuilder) super.withKey(key);
+    }
+
     public List<MarketItem> fetchBazaar() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(ItemMarketSelections.BAZAAR, MarketMapper::ofBazaar);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyAsyncRequestBuilder.java
@@ -16,4 +16,33 @@ public class PropertyAsyncRequestBuilder extends RequestBuilder<PropertiesSelect
         return this;
     }
 
+    @Override
+    public PropertyAsyncRequestBuilder id(long id) {
+        return (PropertyAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public PropertyAsyncRequestBuilder id(String id) {
+        return (PropertyAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public PropertyAsyncRequestBuilder withComment(String comment) {
+        return (PropertyAsyncRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public PropertyAsyncRequestBuilder withParameter(String key, Object value) {
+        return (PropertyAsyncRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public PropertyAsyncRequestBuilder withSelections(String... selections) {
+        return (PropertyAsyncRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public PropertyAsyncRequestBuilder withKey(String key) {
+        return (PropertyAsyncRequestBuilder) super.withKey(key);
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRepeatingRequestBuilder.java
@@ -16,4 +16,33 @@ public class PropertyRepeatingRequestBuilder extends RequestBuilder<PropertiesSe
         return this;
     }
 
+    @Override
+    public PropertyRepeatingRequestBuilder id(long id) {
+        return (PropertyRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public PropertyRepeatingRequestBuilder id(String id) {
+        return (PropertyRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public PropertyRepeatingRequestBuilder withComment(String comment) {
+        return (PropertyRepeatingRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public PropertyRepeatingRequestBuilder withParameter(String key, Object value) {
+        return (PropertyRepeatingRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public PropertyRepeatingRequestBuilder withSelections(String... selections) {
+        return (PropertyRepeatingRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public PropertyRepeatingRequestBuilder withKey(String key) {
+        return (PropertyRepeatingRequestBuilder) super.withKey(key);
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/PropertyRequestBuilder.java
@@ -16,4 +16,33 @@ public class PropertyRequestBuilder extends RequestBuilder<PropertiesSelections>
         return this;
     }
 
+    @Override
+    public PropertyRequestBuilder id(long id) {
+        return (PropertyRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public PropertyRequestBuilder id(String id) {
+        return (PropertyRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public PropertyRequestBuilder withComment(String comment) {
+        return (PropertyRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public PropertyRequestBuilder withParameter(String key, Object value) {
+        return (PropertyRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public PropertyRequestBuilder withSelections(String... selections) {
+        return (PropertyRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public PropertyRequestBuilder withKey(String key) {
+        return (PropertyRequestBuilder) super.withKey(key);
+    }
 }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornAsyncRequestBuilder.java
@@ -22,6 +22,36 @@ public class TornAsyncRequestBuilder extends RequestBuilder<TornSelections> {
         return this;
     }
 
+    @Override
+    public TornAsyncRequestBuilder id(long id) {
+        return (TornAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public TornAsyncRequestBuilder id(String id) {
+        return (TornAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public TornAsyncRequestBuilder withComment(String comment) {
+        return (TornAsyncRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public TornAsyncRequestBuilder withParameter(String key, Object value) {
+        return (TornAsyncRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public TornAsyncRequestBuilder withSelections(String... selections) {
+        return (TornAsyncRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public TornAsyncRequestBuilder withKey(String key) {
+        return (TornAsyncRequestBuilder) super.withKey(key);
+    }
+
     public CompletableFuture<Map<Long, CompanyType>> fetchCompanies() {
         return fetchAsync(TornSelections.COMPANIES, TornMapper::ofCompanies);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRepeatingRequestBuilder.java
@@ -23,6 +23,36 @@ public class TornRepeatingRequestBuilder extends RequestBuilder<TornSelections> 
         return this;
     }
 
+    @Override
+    public TornRepeatingRequestBuilder id(long id) {
+        return (TornRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public TornRepeatingRequestBuilder id(String id) {
+        return (TornRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public TornRepeatingRequestBuilder withComment(String comment) {
+        return (TornRepeatingRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public TornRepeatingRequestBuilder withParameter(String key, Object value) {
+        return (TornRepeatingRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public TornRepeatingRequestBuilder withSelections(String... selections) {
+        return (TornRepeatingRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public TornRepeatingRequestBuilder withKey(String key) {
+        return (TornRepeatingRequestBuilder) super.withKey(key);
+    }
+
     public RepeatingRequestTask<Map<Long, CompanyType>> repeatCompanies(int intervalInSeconds, Consumer<Map<Long, CompanyType>> consumer) {
         return repeating(TornSelections.COMPANIES, intervalInSeconds, TornMapper::ofCompanies, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/TornRequestBuilder.java
@@ -25,6 +25,36 @@ public class TornRequestBuilder extends RequestBuilder<TornSelections> {
         return this;
     }
 
+    @Override
+    public TornRequestBuilder id(long id) {
+        return (TornRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public TornRequestBuilder id(String id) {
+        return (TornRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public TornRequestBuilder withComment(String comment) {
+        return (TornRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public TornRequestBuilder withParameter(String key, Object value) {
+        return (TornRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public TornRequestBuilder withSelections(String... selections) {
+        return (TornRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public TornRequestBuilder withKey(String key) {
+        return (TornRequestBuilder) super.withKey(key);
+    }
+
     public Map<Long, CompanyType> fetchCompanies() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {
         return fetch(TornSelections.COMPANIES, TornMapper::ofCompanies);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserAsyncRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserAsyncRequestBuilder.java
@@ -22,6 +22,36 @@ public class UserAsyncRequestBuilder extends RequestBuilder<UserSelections> {
         return this;
     }
 
+    @Override
+    public UserAsyncRequestBuilder id(long id) {
+        return (UserAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public UserAsyncRequestBuilder id(String id) {
+        return (UserAsyncRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public UserAsyncRequestBuilder withComment(String comment) {
+        return (UserAsyncRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public UserAsyncRequestBuilder withParameter(String key, Object value) {
+        return (UserAsyncRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public UserAsyncRequestBuilder withSelections(String... selections) {
+        return (UserAsyncRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public UserAsyncRequestBuilder withKey(String key) {
+        return (UserAsyncRequestBuilder) super.withKey(key);
+    }
+
     public CompletableFuture<List<Ammo>> fetchAmmo() {
         return fetchAsync(UserSelections.AMMO, UserMapper::ofAmmo);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRepeatingRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRepeatingRequestBuilder.java
@@ -23,6 +23,36 @@ public class UserRepeatingRequestBuilder extends RequestBuilder<UserSelections> 
         return this;
     }
 
+    @Override
+    public UserRepeatingRequestBuilder id(long id) {
+        return (UserRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public UserRepeatingRequestBuilder id(String id) {
+        return (UserRepeatingRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public UserRepeatingRequestBuilder withComment(String comment) {
+        return (UserRepeatingRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public UserRepeatingRequestBuilder withParameter(String key, Object value) {
+        return (UserRepeatingRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public UserRepeatingRequestBuilder withSelections(String... selections) {
+        return (UserRepeatingRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public UserRepeatingRequestBuilder withKey(String key) {
+        return (UserRepeatingRequestBuilder) super.withKey(key);
+    }
+
     public RepeatingRequestTask<List<Ammo>> repeatAmmo(int intervalInSeconds, Consumer<List<Ammo>> consumer) {
         return repeating(UserSelections.AMMO, intervalInSeconds, UserMapper::ofAmmo, consumer);
     }

--- a/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRequestBuilder.java
+++ b/src/main/java/eu/tornplayground/tornapi/requestbuilder/UserRequestBuilder.java
@@ -21,8 +21,37 @@ public class UserRequestBuilder extends RequestBuilder<UserSelections> {
 
     @Override
     public UserRequestBuilder withTornErrorException(boolean throwError) {
-        super.withTornErrorException(throwError);
-        return this;
+        return (UserRequestBuilder) super.withTornErrorException(throwError);
+    }
+
+    @Override
+    public UserRequestBuilder id(long id) {
+        return (UserRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public UserRequestBuilder id(String id) {
+        return (UserRequestBuilder) super.id(id);
+    }
+
+    @Override
+    public UserRequestBuilder withComment(String comment) {
+        return (UserRequestBuilder) super.withComment(comment);
+    }
+
+    @Override
+    public UserRequestBuilder withParameter(String key, Object value) {
+        return (UserRequestBuilder) super.withParameter(key, value);
+    }
+
+    @Override
+    public UserRequestBuilder withSelections(String... selections) {
+        return (UserRequestBuilder) super.withSelections(selections);
+    }
+
+    @Override
+    public UserRequestBuilder withKey(String key) {
+        return (UserRequestBuilder) super.withKey(key);
     }
 
     public List<Ammo> fetchAmmo() throws TornHttpException, TornErrorException, RequestLimitReachedException, IOException {

--- a/src/test/java/eu/tornplayground/tornapi/TornApiTest.java
+++ b/src/test/java/eu/tornplayground/tornapi/TornApiTest.java
@@ -426,7 +426,7 @@ class TornApiTest {
         automaticKeyConsumption.forUser().fetch();
         automaticKeyConsumption.forUser().fetch();
 
-        assertThat(System.currentTimeMillis() - start).isGreaterThanOrEqualTo(2000).isLessThanOrEqualTo(2100);
+        assertThat(System.currentTimeMillis() - start).isGreaterThanOrEqualTo(2000).isLessThanOrEqualTo(2050);
     }
 
 }


### PR DESCRIPTION
the request limiter had a major flaw.. first of all... it didnt matter which key got used.. i didnt make a difference when thinking about queued requests. The key specific lock should handle that. Now there is also no need to lock and unlock the thread again and removing the timestamp and so on...